### PR TITLE
24 python heap types

### DIFF
--- a/python/mfv2d/system.py
+++ b/python/mfv2d/system.py
@@ -34,8 +34,9 @@ class ElementFormSpecification(_ElementFormSpecification):
 
     def __iter__(self) -> Iterator[tuple[str, UnknownFormOrder]]:
         """Iterate over labels and orders of forms specified."""
-        iterator = super().__iter__()
-        for label, order in iterator:
+        # NOTE: workaround needed until PyType_GetModuleByDef is in the stable API :(
+        for i in range(len(self)):
+            label, order = self[i]
             yield (label, UnknownFormOrder(order))
 
     def iter_forms(self) -> Iterator[KFormUnknown]:

--- a/src/algebra/crs_matrix.c
+++ b/src/algebra/crs_matrix.c
@@ -1369,7 +1369,7 @@ static PyMethodDef crs_matrix_methods[] = {
 
 static PyObject *crs_matrix_get_row(const crs_matrix_t *this, PyObject *key)
 {
-    const mfv2d_module_state_t *const state = PyType_GetModuleState(Py_TYPE(this));
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(this));
     if (!state)
         return NULL;
 

--- a/src/algebra/crs_matrix.c
+++ b/src/algebra/crs_matrix.c
@@ -59,6 +59,7 @@ static PyObject *crs_matrix_new(PyTypeObject *type, PyObject *args, PyObject *kw
 
 static void crs_matrix_dealloc(crs_matrix_t *this)
 {
+    PyObject_GC_UnTrack(this);
     jmtxd_matrix_crs_destroy(this->matrix);
     this->matrix = NULL;
     Py_TYPE(this)->tp_free((PyObject *)this);
@@ -1637,6 +1638,7 @@ static PyType_Slot crs_matrix_type_slots[] = {
     {.slot = Py_tp_dealloc, .pfunc = crs_matrix_dealloc},
     {.slot = Py_nb_matrix_multiply, .pfunc = crs_matrix_matmul},
     {.slot = Py_mp_subscript, .pfunc = crs_matrix_get_row},
+    {.slot = Py_tp_traverse, .pfunc = traverse_heap_type},
     {}, // sentinel
 };
 
@@ -1644,6 +1646,6 @@ PyType_Spec crs_matrix_type_spec = {
     .name = "mfv2d._mfv2d.MatrixCRS",
     .basicsize = sizeof(crs_matrix_t),
     .itemsize = 0,
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_HAVE_GC,
     .slots = crs_matrix_type_slots,
 };

--- a/src/algebra/crs_matrix.h
+++ b/src/algebra/crs_matrix.h
@@ -11,7 +11,8 @@ typedef struct
 } crs_matrix_t;
 
 MFV2D_INTERNAL
-extern PyTypeObject crs_matrix_type_object;
+// extern PyTypeObject crs_matrix_type_object;
+extern PyType_Spec crs_matrix_type_spec;
 
 static inline int check_jmtx_call(const jmtx_result res, const char *file, const int line, const char *func,
                                   const char *call)

--- a/src/algebra/svector.c
+++ b/src/algebra/svector.c
@@ -1487,6 +1487,7 @@ static PyType_Slot svec_type_slots[] = {
     {.slot = Py_nb_add, .pfunc = svec_add},
     {.slot = Py_nb_subtract, .pfunc = svec_sub},
     {.slot = Py_nb_multiply, .pfunc = svec_mul},
+    {.slot = Py_tp_traverse, .pfunc = traverse_heap_type},
     {}, // sentinel
 };
 
@@ -1494,6 +1495,6 @@ PyType_Spec svec_type_spec = {
     .name = "mfv2d._mfv2d.SparseVector",
     .basicsize = sizeof(svec_object_t),
     .itemsize = sizeof(entry_t),
-    .flags = Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HEAPTYPE,
+    .flags = Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_HAVE_GC,
     .slots = svec_type_slots,
 };

--- a/src/algebra/svector.c
+++ b/src/algebra/svector.c
@@ -1,7 +1,3 @@
-//
-// Created by jan on 19.3.2025.
-//
-
 #include "svector.h"
 #include "numpy/ndarrayobject.h"
 
@@ -253,6 +249,15 @@ mfv2d_result_t sparse_vector_add_inplace(svector_t *first, const svector_t *seco
 
 static PyObject *svec_repr(const svec_object_t *this)
 {
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(this));
+    if (!state)
+        return NULL;
+    if (!PyObject_TypeCheck(this, state->type_svec))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected a %s but got %R.", state->type_svec->tp_name, Py_TYPE(this));
+        return NULL;
+    }
+
     size_t capacity = 8 * this->count + 64;
     size_t count = 0;
     char *buffer = PyMem_RawMalloc(capacity * sizeof *buffer);
@@ -283,15 +288,70 @@ static PyObject *svec_repr(const svec_object_t *this)
     return str_out;
 }
 
-static PyObject *svec_from_entries(PyTypeObject *type, PyObject *args, PyObject *kwds)
+static PyObject *svec_from_entries(PyTypeObject *type, PyTypeObject *defining_class, PyObject *const *args,
+                                   const Py_ssize_t nargs, PyObject *kwnames)
 {
-    // Check if indice/values are given as two arrays
-    Py_ssize_t n;
-    PyObject *py_indices, *py_values;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "nOO", (char *[4]){"n", "indices", "values", NULL}, &n, &py_indices,
-                                     &py_values))
-    {
+    const mfv2d_module_state_t *const state = PyType_GetModuleState(defining_class);
+    if (!state)
         return NULL;
+
+    if (kwnames != NULL)
+    {
+        PyErr_SetString(PyExc_TypeError, "SparseVector.from_entries() takes no keyword arguments.");
+        return NULL;
+    }
+    const Py_ssize_t kwcnt = kwnames ? PyTuple_GET_SIZE(kwnames) : 0;
+    if (nargs + kwcnt != 3)
+    {
+        PyErr_Format(PyExc_TypeError, "SparseVector.from_entries() takes exactly 3 arguments, got %u.",
+                     (unsigned)(nargs + kwcnt));
+        return NULL;
+    }
+    Py_ssize_t n = -1;
+    PyObject *py_indices = NULL, *py_values = NULL;
+    if (nargs > 0)
+    {
+        n = PyLong_AsSsize_t(args[0]);
+        if (PyErr_Occurred())
+            return NULL;
+        if (nargs > 1)
+        {
+            py_indices = args[1];
+            if (nargs > 2)
+            {
+                py_values = args[2];
+            }
+        }
+    }
+    for (unsigned i = 0; i < kwcnt; ++i)
+    {
+        PyObject *const kwarg = PyTuple_GET_ITEM(kwnames, i);
+        PyObject *const value = args[nargs + i];
+        const char *keyword = PyUnicode_AsUTF8(kwarg);
+        if (!keyword)
+        {
+            return NULL;
+        }
+        if (strcmp(keyword, "indices") == 0)
+        {
+            py_indices = value;
+        }
+        else if (strcmp(keyword, "values") == 0)
+        {
+            py_values = value;
+        }
+        else if (strcmp(keyword, "n") == 0)
+        {
+            n = PyLong_AsSsize_t(value);
+            if (PyErr_Occurred())
+                return NULL;
+        }
+        else
+        {
+            PyErr_Format(PyExc_TypeError, "SparseVector.from_pairs() got an unexpected keyword argument '%s'.",
+                         keyword);
+            return NULL;
+        }
     }
 
     if (n <= 0)
@@ -372,13 +432,72 @@ static PyObject *svec_from_entries(PyTypeObject *type, PyObject *args, PyObject 
     return (PyObject *)this;
 }
 
-static PyObject *svec_array(const svec_object_t *this, PyObject *args, PyObject *kwds)
+static PyObject *svec_array(PyObject *self, PyTypeObject *defining_class, PyObject *const *args, const Py_ssize_t nargs,
+                            PyObject *kwnames)
 {
-    PyArray_Descr *dtype = NULL;
-    int b_copy = 0;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|Op", (char *[3]){"dtype", "copy", NULL}, &dtype, &b_copy))
+    const mfv2d_module_state_t *const state = PyType_GetModuleState(defining_class);
+    if (!state)
     {
         return NULL;
+    }
+
+    if (!PyObject_TypeCheck(self, state->type_svec))
+    {
+        PyErr_Format(PyExc_TypeError, "SparseVector.__array__ must be called on a %s but got %R.",
+                     state->type_svec->tp_name, self);
+        return NULL;
+    }
+
+    const Py_ssize_t nkwds = kwnames ? PyTuple_GET_SIZE(kwnames) : 0;
+
+    if (nargs + nkwds > 2)
+    {
+        PyErr_Format(PyExc_TypeError, "SparseVector.__array__ takes at most two arguments, got %u.",
+                     (unsigned)(nargs + nkwds));
+        return NULL;
+    }
+    PyArray_Descr *dtype = NULL;
+    int b_copy = 0;
+
+    if (nargs > 0)
+    {
+        dtype = (PyArray_Descr *)args[0];
+        if (nargs > 1)
+        {
+            b_copy = PyObject_IsTrue(args[1]);
+            if (PyErr_Occurred())
+            {
+                return NULL;
+            }
+        }
+    }
+
+    for (unsigned i = 0; i < nkwds; ++i)
+    {
+        PyObject *const kwarg = PyTuple_GET_ITEM(kwnames, i);
+        PyObject *const value = args[nargs + i];
+        const char *keyword = PyUnicode_AsUTF8(kwarg);
+        if (!keyword)
+        {
+            return NULL;
+        }
+        if (strcmp(keyword, "dtype") == 0)
+        {
+            dtype = (PyArray_Descr *)value;
+        }
+        else if (strcmp(keyword, "copy") == 0)
+        {
+            b_copy = PyObject_IsTrue(value);
+            if (PyErr_Occurred())
+            {
+                return NULL;
+            }
+        }
+        else
+        {
+            PyErr_Format(PyExc_TypeError, "SparseVector.__array__ got an unexpected keyword argument '%s'.", keyword);
+            return NULL;
+        }
     }
 
     if (!b_copy)
@@ -387,6 +506,7 @@ static PyObject *svec_array(const svec_object_t *this, PyObject *args, PyObject 
         return NULL;
     }
 
+    const svec_object_t *const this = (svec_object_t *)self;
     const npy_intp size = (npy_intp)this->n;
 
     PyArrayObject *const out = (PyArrayObject *)PyArray_SimpleNew(1, &size, NPY_FLOAT64);
@@ -413,9 +533,16 @@ static PyObject *svec_array(const svec_object_t *this, PyObject *args, PyObject 
 
 static PyObject *svec_get(const svec_object_t *this, PyObject *py_idx)
 {
-    const mfv2d_module_state_t *const state = PyType_GetModuleState(Py_TYPE(this));
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(this));
     if (!state)
         return NULL;
+
+    if (!PyObject_TypeCheck(this, state->type_svec))
+    {
+        PyErr_Format(PyExc_TypeError, "SparseVector.__get__ must be called on a %s but got %R.",
+                     state->type_svec->tp_name, this);
+        return NULL;
+    }
 
     if (PySlice_Check(py_idx))
     {
@@ -493,11 +620,18 @@ static PyObject *svec_get(const svec_object_t *this, PyObject *py_idx)
     return PyFloat_FromDouble(this->entries[pos].value);
 }
 
-static PyObject *svec_concatenate(PyTypeObject *type, PyObject *const *args, const Py_ssize_t nargs)
+static PyObject *svec_concatenate(PyTypeObject *type, PyTypeObject *defining_class, PyObject *const *args,
+                                  const Py_ssize_t nargs, PyObject *kwnames)
 {
-    const mfv2d_module_state_t *const state = PyType_GetModuleState(type);
+    const mfv2d_module_state_t *const state = PyType_GetModuleState(defining_class);
     if (!state)
         return NULL;
+
+    if (kwnames != NULL)
+    {
+        PyErr_SetString(PyExc_TypeError, "SparseVector.concatenate() takes no keyword arguments.");
+        return NULL;
+    }
 
     for (unsigned i = 0; i < nargs; ++i)
     {
@@ -537,15 +671,19 @@ static PyObject *svec_concatenate(PyTypeObject *type, PyObject *const *args, con
     return (PyObject *)this;
 }
 
-static PyObject *svec_from_pairs(PyTypeObject *type, PyObject *args, PyObject *kwds)
+static PyObject *svec_from_pairs(PyTypeObject *type, PyTypeObject *defining_class, PyObject *const *args,
+                                 const Py_ssize_t nargs, PyObject *kwnames)
 {
-    if (kwds != NULL)
+    const mfv2d_module_state_t *const state = PyType_GetModuleState(defining_class);
+    if (!state)
+        return NULL;
+
+    if (kwnames != NULL)
     {
-        PyErr_SetString(PyExc_TypeError, "SparseVector.from_pairs takes no keyword arguments.");
+        PyErr_SetString(PyExc_TypeError, "SparseVector.from_pairs() takes no keyword arguments.");
         return NULL;
     }
 
-    const Py_ssize_t nargs = PyTuple_GET_SIZE(args);
     if (nargs < 1)
     {
         PyErr_SetString(PyExc_TypeError, "At least one argument must be provided.");
@@ -553,7 +691,7 @@ static PyObject *svec_from_pairs(PyTypeObject *type, PyObject *args, PyObject *k
     }
 
     // Parse first arg (element) and the rest as *pairs
-    const Py_ssize_t dim_size = PyLong_AsSsize_t(PyTuple_GET_ITEM(args, 0));
+    const Py_ssize_t dim_size = PyLong_AsSsize_t(args[0]);
     if (PyErr_Occurred())
         return NULL;
 
@@ -573,7 +711,7 @@ static PyObject *svec_from_pairs(PyTypeObject *type, PyObject *args, PyObject *k
     // Fill arrays
     for (unsigned i = 1; i < nargs; ++i)
     {
-        PyObject *const pair = PyTuple_GET_ITEM(args, i);
+        PyObject *const pair = args[i];
 
         if (!PyTuple_Check(pair) || PyTuple_GET_SIZE(pair) != 2)
         {
@@ -616,26 +754,24 @@ static PyObject *svec_from_pairs(PyTypeObject *type, PyObject *args, PyObject *k
     return (PyObject *)self;
 }
 
-static PyObject *svec_dot(const svec_object_t *this, const svec_object_t *that)
+static PyObject *svec_dot(PyObject *self, PyTypeObject *defining_class, PyObject *const *args, const Py_ssize_t nargs,
+                          PyObject *kwnames)
 {
-    PyObject *const current_exception = PyErr_GetHandledException();
-    PyErr_SetHandledException(NULL);
-    PyObject *mod = PyType_GetModule(Py_TYPE(this));
-    if (!mod)
-    {
-        PyErr_Clear();
-        mod = PyType_GetModule(Py_TYPE(that));
-        if (!mod)
-        {
-            Py_XDECREF(current_exception);
-            return NULL;
-        }
-    }
-    PyErr_SetHandledException(current_exception);
-
-    mfv2d_module_state_t *const state = PyType_GetModuleState(Py_TYPE(this));
+    mfv2d_module_state_t *const state = PyType_GetModuleState(defining_class);
     if (!state)
         return NULL;
+    if (nargs != 1)
+    {
+        PyErr_Format(PyExc_TypeError, "Method requires exactly one argument, got %u.", (unsigned)nargs);
+        return NULL;
+    }
+    if (kwnames != NULL)
+    {
+        PyErr_SetString(PyExc_TypeError, "Method takes no keyword arguments.");
+        return NULL;
+    }
+    svec_object_t *const this = (svec_object_t *)self;
+    svec_object_t *const that = (svec_object_t *)args[0];
 
     if (!PyObject_TypeCheck(that, state->type_svec) || !PyObject_TypeCheck(this, state->type_svec))
     {
@@ -707,8 +843,8 @@ static int svec_parse_merge_mode(const char name[], svec_merge_mode_t *out)
     return -1;
 }
 
-static PyObject *svec_merge_to_dense(PyObject *Py_UNUSED(mod), PyObject *const args[], const Py_ssize_t nargs,
-                                     PyObject *kwnames)
+static PyObject *svec_merge_to_dense(PyTypeObject *Py_UNUSED(type), PyTypeObject *defining_class, PyObject *const *args,
+                                     const Py_ssize_t nargs, PyObject *kwnames)
 {
     svec_merge_mode_t merge_mode = MERGE_MODE_LAST;
     if (kwnames != NULL)
@@ -762,7 +898,7 @@ static PyObject *svec_merge_to_dense(PyObject *Py_UNUSED(mod), PyObject *const a
         return NULL;
     }
 
-    const mfv2d_module_state_t *const state = PyType_GetModuleState(Py_TYPE(args[0]));
+    const mfv2d_module_state_t *const state = PyType_GetModuleState(defining_class);
     if (!state)
         return NULL;
 
@@ -794,7 +930,7 @@ static PyObject *svec_merge_to_dense(PyObject *Py_UNUSED(mod), PyObject *const a
         return PyObject_CallMethod(args[0], "__array__", NULL);
     }
 
-    const npy_intp size = (npy_intp)n;
+    const npy_intp size = n;
     PyArrayObject *const array = (PyArrayObject *)PyArray_SimpleNew(1, &size, NPY_FLOAT64);
 
     if (!array)
@@ -873,14 +1009,14 @@ static PyMethodDef svec_methods[] = {
     {
         .ml_name = "__array__",
         .ml_meth = (void *)svec_array,
-        .ml_flags = METH_VARARGS | METH_KEYWORDS,
+        .ml_flags = METH_FASTCALL | METH_KEYWORDS | METH_METHOD,
         .ml_doc = "__array__(self, dtype=None, copy=None) -> numpy.ndarray[int]\n"
                   "Convert to numpy array.\n",
     },
     {
         .ml_name = "from_entries",
         .ml_meth = (void *)svec_from_entries,
-        .ml_flags = METH_CLASS | METH_KEYWORDS | METH_VARARGS,
+        .ml_flags = METH_CLASS | METH_FASTCALL | METH_KEYWORDS | METH_METHOD,
         .ml_doc = "from_entries(n: int, indices: array_like, values: array_like) -> SparseVector:\n"
                   "Create sparse vector from an array of indices and values.\n"
                   "\n"
@@ -903,7 +1039,7 @@ static PyMethodDef svec_methods[] = {
     {
         .ml_name = "from_pairs",
         .ml_meth = (void *)svec_from_pairs,
-        .ml_flags = METH_CLASS | METH_KEYWORDS | METH_VARARGS,
+        .ml_flags = METH_CLASS | METH_FASTCALL | METH_KEYWORDS | METH_METHOD,
         .ml_doc = "from_pairs(n: int, *pairs: tuple[int, float], /) -> SparseVector:\n"
                   "Create sparse vector from an index-coefficient pairs.\n"
                   "\n"
@@ -923,7 +1059,7 @@ static PyMethodDef svec_methods[] = {
     {
         .ml_name = "concatenate",
         .ml_meth = (void *)svec_concatenate,
-        .ml_flags = METH_FASTCALL | METH_CLASS,
+        .ml_flags = METH_FASTCALL | METH_KEYWORDS | METH_METHOD | METH_CLASS,
         .ml_doc = "concatenate(*vectors: SparseVector) -> SparseVector:\n"
                   "Merge sparse vectors together into a single vector.\n"
                   "\n"
@@ -940,7 +1076,7 @@ static PyMethodDef svec_methods[] = {
     {
         .ml_name = "dot",
         .ml_meth = (void *)svec_dot,
-        .ml_flags = METH_O,
+        .ml_flags = METH_FASTCALL | METH_KEYWORDS | METH_METHOD,
         .ml_doc = "dot(other: SparseVector) -> float\n"
                   "Compute dot product of two sparse vectors.\n"
                   "\n"
@@ -958,7 +1094,7 @@ static PyMethodDef svec_methods[] = {
     {
         .ml_name = "merge_to_dense",
         .ml_meth = (void *)svec_merge_to_dense,
-        .ml_flags = METH_FASTCALL | METH_KEYWORDS | METH_STATIC,
+        .ml_flags = METH_FASTCALL | METH_KEYWORDS | METH_METHOD | METH_CLASS,
         .ml_doc =
             "merge_to_dense(*args: SparseVector, duplicates: typing.Literal[\"first\", \"last\", \"sum\", \"error\"] = "
             "\"first\")\n"
@@ -1102,9 +1238,14 @@ static PyObject *return_py_bool(const int v)
 
 static PyObject *svec_richcompare(const svec_object_t *self, PyObject *other, int op)
 {
-    const mfv2d_module_state_t *const state = PyType_GetModuleState(Py_TYPE(self));
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
     if (!state)
         return NULL;
+
+    if (!PyObject_TypeCheck(other, state->type_svec) || !PyObject_TypeCheck(self, state->type_svec))
+    {
+        Py_RETURN_NOTIMPLEMENTED;
+    }
 
     if (op != Py_EQ && op != Py_NE)
     {
@@ -1236,7 +1377,7 @@ static PyObject *svec_richcompare(const svec_object_t *self, PyObject *other, in
 
 static PyObject *svec_add(const svec_object_t *self, const svec_object_t *other)
 {
-    const mfv2d_module_state_t *const state = PyType_GetModuleState(Py_TYPE(self));
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
     if (!state)
     {
         PyErr_Clear();
@@ -1268,7 +1409,7 @@ static PyObject *svec_add(const svec_object_t *self, const svec_object_t *other)
 
 static PyObject *svec_sub(const svec_object_t *self, const svec_object_t *other)
 {
-    const mfv2d_module_state_t *const state = PyType_GetModuleState(Py_TYPE(self));
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
     if (!state)
     {
         PyErr_Clear();
@@ -1307,7 +1448,7 @@ static PyObject *svec_sub(const svec_object_t *self, const svec_object_t *other)
 
 static PyObject *svec_mul(const svec_object_t *self, PyObject *other)
 {
-    const mfv2d_module_state_t *const state = PyType_GetModuleState(Py_TYPE(self));
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
     if (!state)
     {
         PyErr_Clear();
@@ -1336,25 +1477,6 @@ static PyObject *svec_mul(const svec_object_t *self, PyObject *other)
     sparse_vector_del(&prod_vector, &SYSTEM_ALLOCATOR);
     return (PyObject *)out;
 }
-
-// static PyNumberMethods svec_as_number = {
-//     .nb_add = (binaryfunc)svec_add,
-//     .nb_subtract = (binaryfunc)svec_sub,
-//     .nb_multiply = (binaryfunc)svec_mul,
-// };
-//
-// PyTypeObject svec_type_object = {
-//     .ob_base = PyVarObject_HEAD_INIT(NULL, 0).tp_name = "mfv2d._mfv2d.SparseVector",
-//     .tp_basicsize = sizeof(svec_object_t),
-//     .tp_itemsize = sizeof(entry_t),
-//     .tp_repr = (reprfunc)svec_repr,
-//     .tp_as_mapping = &svec_mapping,
-//     .tp_flags = Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DEFAULT,
-//     .tp_richcompare = (richcmpfunc)svec_richcompare,
-//     .tp_methods = svec_methods,
-//     .tp_getset = svec_get_set,
-//     .tp_as_number = &svec_as_number,
-// };
 
 static PyType_Slot svec_type_slots[] = {
     {.slot = Py_tp_repr, .pfunc = svec_repr},

--- a/src/algebra/svector.h
+++ b/src/algebra/svector.h
@@ -29,7 +29,8 @@ typedef struct
 } svec_object_t;
 
 MFV2D_INTERNAL
-extern PyTypeObject svec_type_object;
+// extern PyTypeObject svec_type_object;
+extern PyType_Spec svec_type_spec;
 
 /**
  * Create a new sparse vector with no entries and desired capacity.
@@ -77,11 +78,12 @@ mfv2d_result_t sparse_vector_append(svector_t *this, entry_t e, const allocator_
 /**
  * Create a Python sparse vector object based on the given sparse vector.
  *
+ * @param svec_type_object Type object to use to create the Python type.
  * @param this Vector that is to be converted.
  * @return Pointer to the object or NULL on allocation failure.
  */
 MFV2D_INTERNAL
-svec_object_t *sparse_vector_to_python(const svector_t *this);
+svec_object_t *sparse_vector_to_python(PyTypeObject *svec_type_object, const svector_t *this);
 
 /**
  * Performs a deep copy of a vector to another memory location.

--- a/src/algebra/system_objects.c
+++ b/src/algebra/system_objects.c
@@ -200,6 +200,7 @@ static PyObject *system_new(PyTypeObject *type, PyObject *args, PyObject *kwargs
 
 static void system_dealloc(PyObject *self)
 {
+    PyObject_GC_UnTrack(self);
     system_object_t *const this = (system_object_t *)self;
     if (this->system.blocks)
     {
@@ -703,16 +704,21 @@ PyDoc_STRVAR(system_object_docstring,
 // };
 
 static PyType_Slot system_object_slots[] = {
-    {.slot = Py_tp_str, .pfunc = system_str},         {.slot = Py_tp_doc, .pfunc = (void *)system_object_docstring},
-    {.slot = Py_tp_methods, .pfunc = system_methods}, {.slot = Py_tp_new, .pfunc = system_new},
-    {.slot = Py_tp_dealloc, .pfunc = system_dealloc}, {}, // sentinel
+    {.slot = Py_tp_str, .pfunc = system_str},
+    {.slot = Py_tp_doc, .pfunc = (void *)system_object_docstring},
+    {.slot = Py_tp_methods, .pfunc = system_methods},
+    {.slot = Py_tp_new, .pfunc = system_new},
+    {.slot = Py_tp_dealloc, .pfunc = system_dealloc},
+    {.slot = Py_tp_traverse, .pfunc = traverse_heap_type},
+    {}, // sentinel
 };
 
 PyType_Spec system_object_spec = {
     .name = "mfv2d._mfv2d.LinearSystem",
     .basicsize = sizeof(system_object_t),
     .itemsize = 0,
-    .flags = Py_TPFLAGS_BASETYPE | Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HEAPTYPE,
+    .flags =
+        Py_TPFLAGS_BASETYPE | Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_HAVE_GC,
     .slots = system_object_slots,
 };
 
@@ -825,6 +831,7 @@ static PyObject *dense_vector_new(PyTypeObject *type, PyObject *args, PyObject *
 
 static void dense_vector_destroy(PyObject *self)
 {
+    PyObject_GC_UnTrack(self);
     dense_vector_object_t *const this = (dense_vector_object_t *)self;
     deallocate(&SYSTEM_ALLOCATOR, this->offsets);
     this->offsets = NULL;
@@ -1385,6 +1392,7 @@ static PyType_Slot dense_vector_slots[] = {
     {.slot = Py_tp_getset, .pfunc = dense_vector_getset},
     {.slot = Py_tp_dealloc, .pfunc = dense_vector_destroy},
     {.slot = Py_tp_new, .pfunc = dense_vector_new},
+    {.slot = Py_tp_traverse, .pfunc = traverse_heap_type},
     {}, // sentinel
 };
 
@@ -1392,7 +1400,8 @@ PyType_Spec dense_vector_object_type_spec = {
     .name = "mfv2d._mfv2d.DenseVector",
     .basicsize = sizeof(dense_vector_object_t),
     .itemsize = 0,
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE,
+    .flags =
+        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_HAVE_GC,
     .slots = dense_vector_slots,
 };
 
@@ -1529,6 +1538,7 @@ static PyObject *trace_vector_str(PyObject *self)
 
 static void trace_vector_destroy(PyObject *self)
 {
+    PyObject_GC_UnTrack(self);
     trace_vector_object_t *const this = (trace_vector_object_t *)self;
     for (unsigned i = 0; i < this->parent->system.n_blocks; ++i)
     {
@@ -2120,20 +2130,6 @@ static PyGetSetDef trace_vector_getset[] = {
 PyDoc_STRVAR(trace_vector_object_type_docstring,
              "Type used to represent the \"trace\" system variables associated with constraints.\n");
 
-// PyTypeObject trace_vector_object_type = {
-//     PyVarObject_HEAD_INIT(NULL, 0) //
-//         .tp_name = "mfv2d._mfv2d.TraceVector",
-//     .tp_basicsize = sizeof(trace_vector_object_t),
-//     .tp_itemsize = 0,
-//     .tp_str = trace_vector_str,
-//     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_BASETYPE,
-//     .tp_doc = trace_vector_object_type_docstring,
-//     .tp_methods = trace_vector_methods,
-//     .tp_getset = trace_vector_getset,
-//     .tp_new = trace_vector_new,
-//     .tp_dealloc = trace_vector_destroy,
-// };
-
 static PyType_Slot trace_vector_slots[] = {
     {.slot = Py_tp_str, .pfunc = trace_vector_str},
     {.slot = Py_tp_doc, .pfunc = (void *)trace_vector_object_type_docstring},
@@ -2141,6 +2137,8 @@ static PyType_Slot trace_vector_slots[] = {
     {.slot = Py_tp_getset, .pfunc = trace_vector_getset},
     {.slot = Py_tp_new, .pfunc = trace_vector_new},
     {.slot = Py_tp_dealloc, .pfunc = trace_vector_destroy},
+    {.slot = Py_tp_traverse, .pfunc = traverse_heap_type},
+    {.slot = Py_tp_traverse, .pfunc = traverse_heap_type},
     {}, // sentinel
 };
 
@@ -2148,6 +2146,7 @@ PyType_Spec trace_vector_type_spec = {
     .name = "mfv2d._mfv2d.TraceVector",
     .basicsize = sizeof(trace_vector_object_t),
     .itemsize = 0,
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE,
+    .flags =
+        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_HAVE_GC,
     .slots = trace_vector_slots,
 };

--- a/src/algebra/system_objects.h
+++ b/src/algebra/system_objects.h
@@ -10,7 +10,8 @@ typedef struct
 } system_object_t;
 
 MFV2D_INTERNAL
-extern PyTypeObject system_object_type;
+// extern PyTypeObject system_object_type;
+extern PyType_Spec system_object_spec;
 
 static inline const system_t *system_object_as_system(const system_object_t *const this)
 {
@@ -26,7 +27,8 @@ typedef struct
 } dense_vector_object_t;
 
 MFV2D_INTERNAL
-extern PyTypeObject dense_vector_object_type;
+// extern PyTypeObject dense_vector_object_type;
+extern PyType_Spec dense_vector_object_type_spec;
 
 static inline dense_vector_t dense_vector_object_as_dense_vector(const dense_vector_object_t *const this)
 {
@@ -42,7 +44,8 @@ typedef struct
 } trace_vector_object_t;
 
 MFV2D_INTERNAL
-extern PyTypeObject trace_vector_object_type;
+// extern PyTypeObject trace_vector_object_type;
+extern PyType_Spec trace_vector_type_spec;
 
 static inline trace_vector_t trace_vector_object_as_trace_vector(const trace_vector_object_t *const this)
 {

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -220,6 +220,11 @@ static argument_status_t validate_arg_specs(const unsigned n, const argument_t s
                 return ARG_STATUS_BAD_SPECS;
             }
         }
+        if (specs[i].p_val == NULL)
+        {
+            PyErr_Format(PyExc_RuntimeError, "Argument %u has no value pointer.", i);
+            return ARG_STATUS_BAD_SPECS;
+        }
         switch (specs[i].type)
         {
         case ARG_TYPE_PYTHON:
@@ -249,29 +254,29 @@ argument_status_t extract_argument_value(const unsigned i, PyObject *const val, 
                          Py_TYPE(val));
             return ARG_STATUS_INVALID;
         }
-        arg->value_python = val;
+        *(PyObject **)arg->p_val = val;
         break;
 
     case ARG_TYPE_BOOL:
-        arg->value_bool = PyObject_IsTrue(val);
+        *(int *)arg->p_val = PyObject_IsTrue(val);
         if (PyErr_Occurred())
             return ARG_STATUS_INVALID;
         break;
 
     case ARG_TYPE_INT:
-        arg->value_int = PyLong_AsSsize_t(val);
+        *(Py_ssize_t *)arg->p_val = PyNumber_AsSsize_t(val, PyExc_ValueError);
         if (PyErr_Occurred())
             return ARG_STATUS_INVALID;
         break;
 
     case ARG_TYPE_DOUBLE:
-        arg->value_double = PyFloat_AsDouble(val);
+        *(double *)arg->p_val = PyFloat_AsDouble(val);
         if (PyErr_Occurred())
             return ARG_STATUS_INVALID;
         break;
 
     case ARG_TYPE_STRING:
-        arg->value_string = PyUnicode_AsUTF8(val);
+        *(const char **)arg->p_val = PyUnicode_AsUTF8(val);
         if (PyErr_Occurred())
             return ARG_STATUS_INVALID;
         break;

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -426,6 +426,11 @@ argument_status_t parse_arguments(argument_t specs[const], PyObject *const args[
 
     return ARG_STATUS_SUCCESS;
 }
+int traverse_heap_type(PyObject *op, const visitproc visit, void *arg)
+{
+    Py_VISIT(Py_TYPE(op));
+    return 0;
+}
 
 const char *arg_status_strings[] = {
     [ARG_STATUS_SUCCESS] = "Parsed correctly",

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -206,4 +206,7 @@ static inline int parse_arguments_check(argument_t specs[], PyObject *const args
     return 0;
 }
 
+MFV2D_INTERNAL
+int traverse_heap_type(PyObject *op, visitproc visit, void *arg);
+
 #endif // COMMON_H

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -168,13 +168,14 @@ typedef struct
     int found;
     int kw_only;
     const char *kwname;
-    union {
-        Py_ssize_t value_int;
-        int value_bool;
-        double value_double;
-        PyObject *value_python;
-        const char *value_string;
-    };
+    // union {
+    //     Py_ssize_t value_int;
+    //     int value_bool;
+    //     double value_double;
+    //     PyObject *value_python;
+    //     const char *value_string;
+    // };
+    void *p_val;
     PyTypeObject *type_check;
 } argument_t;
 
@@ -203,7 +204,8 @@ static inline int parse_arguments_check(argument_t specs[], PyObject *const args
     const argument_status_t res = parse_arguments(specs, args, nargs, kwnames);
     if (res != ARG_STATUS_SUCCESS)
     {
-        raise_exception_from_current(PyExc_TypeError, "Invalid arguments to function (%s).", argument_status_str(res));
+        // raise_exception_from_current(PyExc_TypeError, "Invalid arguments to function (%s).",
+        // argument_status_str(res));
         return -1;
     }
     return 0;

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -122,6 +122,17 @@ typedef struct
     PyTypeObject *type_surface;
     PyTypeObject *type_man2d;
     PyTypeObject *type_mesh;
+    PyTypeObject *type_int_rule;
+    PyTypeObject *type_basis1d;
+    PyTypeObject *type_basis2d;
+    PyTypeObject *type_fem_space;
+    PyTypeObject *type_form_spec;
+    PyTypeObject *type_form_spec_iter;
+    PyTypeObject *type_svec;
+    PyTypeObject *type_crs_matrix;
+    PyTypeObject *type_system;
+    PyTypeObject *type_trace_vector;
+    PyTypeObject *type_dense_vector;
 } mfv2d_module_state_t;
 
 #endif // COMMON_H

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -159,6 +159,7 @@ typedef enum
     ARG_TYPE_DOUBLE,
     ARG_TYPE_STRING,
     ARG_TYPE_PYTHON,
+    ARG_TYPE_SEQUENCE,
 } argument_type_t;
 
 typedef struct
@@ -168,27 +169,21 @@ typedef struct
     int found;
     int kw_only;
     const char *kwname;
-    // union {
-    //     Py_ssize_t value_int;
-    //     int value_bool;
-    //     double value_double;
-    //     PyObject *value_python;
-    //     const char *value_string;
-    // };
     void *p_val;
     PyTypeObject *type_check;
 } argument_t;
 
 typedef enum
 {
-    ARG_STATUS_SUCCESS,   // Parsed correctly
-    ARG_STATUS_MISSING,   // Argument was missing
-    ARG_STATUS_INVALID,   // Argument had invalid value
-    ARG_STATUS_DUPLICATE, // Argument was found twice
-    ARG_STATUS_BAD_SPECS, // Specifications were incorrect
-    ARG_STATUS_KW_AS_POS, // Keyword argument was specified as a positional argument
-    ARG_STATUS_NO_KW,     // No argument has this keyword
-    ARG_STATUS_UNKNOWN,   // Unknown error
+    ARG_STATUS_SUCCESS,        // Parsed correctly
+    ARG_STATUS_MISSING,        // Argument was missing
+    ARG_STATUS_INVALID,        // Argument had invalid value
+    ARG_STATUS_DUPLICATE,      // Argument was found twice
+    ARG_STATUS_BAD_SPECS,      // Specifications were incorrect
+    ARG_STATUS_KW_AS_POS,      // Keyword argument was specified as a positional argument
+    ARG_STATUS_NO_KW,          // No argument has this keyword
+    ARG_STATUS_UNKNOWN,        // Unknown error
+    ARG_STATUS_KW_IN_SEQUENCE, // Keyword argument was found in a sequence
 } argument_status_t;
 
 MFV2D_INTERNAL

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -115,4 +115,13 @@ typedef struct
     double x3, y3;
 } quad_info_t;
 
+typedef struct
+{
+    PyTypeObject *type_geoid;
+    PyTypeObject *type_line;
+    PyTypeObject *type_surface;
+    PyTypeObject *type_man2d;
+    PyTypeObject *type_mesh;
+} mfv2d_module_state_t;
+
 #endif // COMMON_H

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -135,4 +135,20 @@ typedef struct
     PyTypeObject *type_dense_vector;
 } mfv2d_module_state_t;
 
+/**
+ * @brief Retrieves the module state associated with a given Python type.
+ *
+ * This function extracts the module state associated with a Python type object.
+ * It first retrieves the module corresponding to the provided type and then
+ * accesses the module state. If the module cannot be resolved or the state is
+ * unavailable, the function returns `NULL` and raises a Python TypeError.
+ *
+ *
+ * @param type Pointer to the Python type object for which the module state is to be retrieved.
+ * @return A pointer to the module state structure (`mfv2d_module_state_t`) if successful,
+ *         or `NULL` if the module or its state could not be accessed.
+ */
+MFV2D_INTERNAL
+const mfv2d_module_state_t *mfv2d_state_from_type(PyTypeObject *type);
+
 #endif // COMMON_H

--- a/src/evaluation/bytecode.c
+++ b/src/evaluation/bytecode.c
@@ -302,12 +302,16 @@ const char check_bytecode_docstr[] = "check_bytecode(form_specs: _ElemenetFormsS
                                      "\n"
                                      "This function is meant for testing.\n";
 
-PyObject *check_bytecode(PyObject *Py_UNUSED(module), PyObject *args, PyObject *kwds)
+PyObject *check_bytecode(PyObject *mod, PyObject *args, PyObject *kwds)
 {
+    const mfv2d_module_state_t *const state = PyModule_GetState(mod);
+    if (!state)
+        return NULL;
+
     element_form_spec_t *form_specs;
     PyObject *expression;
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!", (char *const[3]){"form_specs", "expression", NULL},
-                                     &element_form_spec_type, &form_specs, &PyTuple_Type, &expression))
+                                     state->type_form_spec, &form_specs, &PyTuple_Type, &expression))
     {
         return NULL;
     }

--- a/src/evaluation/element_system.c
+++ b/src/evaluation/element_system.c
@@ -10,8 +10,12 @@
 #include "forms.h"
 
 MFV2D_INTERNAL
-PyObject *compute_element_matrix(PyObject *Py_UNUSED(self), PyObject *args, PyObject *kwargs)
+PyObject *compute_element_matrix(PyObject *mod, PyObject *args, PyObject *kwargs)
 {
+    const mfv2d_module_state_t *const state = PyModule_GetState(mod);
+    if (!state)
+        return NULL;
+
     PyArrayObject *return_value = NULL;
     element_form_spec_t *form_specs = NULL;
     PyObject *expressions = NULL;
@@ -23,14 +27,14 @@ PyObject *compute_element_matrix(PyObject *Py_UNUSED(self), PyObject *args, PyOb
                               "degrees_of_freedom", "stack_memory", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!OO!|O!n", kwlist,
-                                     &element_form_spec_type,    // for type checking
-                                     &form_specs,                // ElementFormsSpecs
-                                     &expressions,               // _CompiledCodeMatrix (PyObject*)
-                                     &element_fem_space_2d_type, // for type checking
-                                     &element_fem_space,         // element cache
-                                     &PyArray_Type,              // for type checking
-                                     &py_degrees_of_freedom,     // array
-                                     &stack_memory               // int
+                                     &element_form_spec_type, // for type checking
+                                     &form_specs,             // ElementFormsSpecs
+                                     &expressions,            // _CompiledCodeMatrix (PyObject*)
+                                     state->type_fem_space,   // for type checking
+                                     &element_fem_space,      // element cache
+                                     &PyArray_Type,           // for type checking
+                                     &py_degrees_of_freedom,  // array
+                                     &stack_memory            // int
                                      ))
     {
         return NULL;
@@ -238,8 +242,11 @@ const char compute_element_matrix_docstr[] =
     "    Element matrix for the specified system.\n";
 
 MFV2D_INTERNAL
-PyObject *compute_element_vector(PyObject *Py_UNUSED(self), PyObject *args, PyObject *kwargs)
+PyObject *compute_element_vector(PyObject *mod, PyObject *args, PyObject *kwargs)
 {
+    const mfv2d_module_state_t *const state = PyModule_GetState(mod);
+    if (!state)
+        return NULL;
 
     PyArrayObject *return_value = NULL;
     element_form_spec_t *form_specs = NULL;
@@ -252,14 +259,14 @@ PyObject *compute_element_vector(PyObject *Py_UNUSED(self), PyObject *args, PyOb
                               "degrees_of_freedom", "stack_memory ", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!OO!O!|n", kwlist,
-                                     &element_form_spec_type,    // for type checking
-                                     &form_specs,                // _ElementFormsSpecs
-                                     &expressions,               // (PyObject*)
-                                     &element_fem_space_2d_type, // for type checking
-                                     &element_fem_space,         // element cache
-                                     &PyArray_Type,              // For type checking
-                                     &solution,                  // np.ndarray
-                                     &stack_memory               // int
+                                     &element_form_spec_type, // for type checking
+                                     &form_specs,             // _ElementFormsSpecs
+                                     &expressions,            // (PyObject*)
+                                     state->type_fem_space,   // for type checking
+                                     &element_fem_space,      // element cache
+                                     &PyArray_Type,           // For type checking
+                                     &solution,               // np.ndarray
+                                     &stack_memory            // int
                                      ))
     {
         return NULL;
@@ -470,16 +477,20 @@ const char compute_element_projector_docstr[] =
     "    Tuple where each entry is the respective projection matrix for that form.\n";
 
 MFV2D_INTERNAL
-PyObject *compute_element_projector(PyObject *Py_UNUSED(self), PyObject *args, PyObject *kwds)
+PyObject *compute_element_projector(PyObject *mod, PyObject *args, PyObject *kwds)
 {
+    const mfv2d_module_state_t *const state = PyModule_GetState(mod);
+    if (!state)
+        return NULL;
+
     element_form_spec_t *form_specs;
     basis_2d_t *basis_in;
     element_fem_space_2d_t *space_out;
     int dual = 0;
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!O!|p",
                                      (char *const[]){"form_orders", "basis_in", "space_out", "dual", NULL},
-                                     &element_form_spec_type, &form_specs, &basis_2d_type, &basis_in,
-                                     &element_fem_space_2d_type, &space_out, &dual))
+                                     &element_form_spec_type, &form_specs, state->type_basis2d, &basis_in,
+                                     state->type_fem_space, &space_out, &dual))
     {
         return NULL;
     }
@@ -656,15 +667,19 @@ const char compute_element_mass_matrix_docstr[] =
     "array\n"
     "    Mass matrix (or its inverse if specified) for the appropriate form.\n";
 
-PyObject *compute_element_mass_matrix(PyObject *Py_UNUSED(self), PyObject *args, PyObject *kwds)
+PyObject *compute_element_mass_matrix(PyObject *mod, PyObject *args, PyObject *kwds)
 {
+    const mfv2d_module_state_t *const state = PyModule_GetState(mod);
+    if (!state)
+        return NULL;
+
     form_order_t order;
     basis_2d_t *basis = NULL;
     PyArrayObject *corners = NULL;
     int inverse = 0;
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "iO!O!|p",
                                      (char *const[5]){"order", "corners", "basis", "inverse", NULL}, &order,
-                                     &PyArray_Type, &corners, &basis_2d_type, &basis, &inverse))
+                                     &PyArray_Type, &corners, state->type_basis2d, &basis, &inverse))
     {
         return NULL;
     }

--- a/src/evaluation/element_system.c
+++ b/src/evaluation/element_system.c
@@ -27,14 +27,14 @@ PyObject *compute_element_matrix(PyObject *mod, PyObject *args, PyObject *kwargs
                               "degrees_of_freedom", "stack_memory", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!OO!|O!n", kwlist,
-                                     &element_form_spec_type, // for type checking
-                                     &form_specs,             // ElementFormsSpecs
-                                     &expressions,            // _CompiledCodeMatrix (PyObject*)
-                                     state->type_fem_space,   // for type checking
-                                     &element_fem_space,      // element cache
-                                     &PyArray_Type,           // for type checking
-                                     &py_degrees_of_freedom,  // array
-                                     &stack_memory            // int
+                                     state->type_form_spec,  // for type checking
+                                     &form_specs,            // ElementFormsSpecs
+                                     &expressions,           // _CompiledCodeMatrix (PyObject*)
+                                     state->type_fem_space,  // for type checking
+                                     &element_fem_space,     // element cache
+                                     &PyArray_Type,          // for type checking
+                                     &py_degrees_of_freedom, // array
+                                     &stack_memory           // int
                                      ))
     {
         return NULL;
@@ -259,14 +259,14 @@ PyObject *compute_element_vector(PyObject *mod, PyObject *args, PyObject *kwargs
                               "degrees_of_freedom", "stack_memory ", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!OO!O!|n", kwlist,
-                                     &element_form_spec_type, // for type checking
-                                     &form_specs,             // _ElementFormsSpecs
-                                     &expressions,            // (PyObject*)
-                                     state->type_fem_space,   // for type checking
-                                     &element_fem_space,      // element cache
-                                     &PyArray_Type,           // For type checking
-                                     &solution,               // np.ndarray
-                                     &stack_memory            // int
+                                     state->type_form_spec, // for type checking
+                                     &form_specs,           // _ElementFormsSpecs
+                                     &expressions,          // (PyObject*)
+                                     state->type_fem_space, // for type checking
+                                     &element_fem_space,    // element cache
+                                     &PyArray_Type,         // For type checking
+                                     &solution,             // np.ndarray
+                                     &stack_memory          // int
                                      ))
     {
         return NULL;
@@ -489,7 +489,7 @@ PyObject *compute_element_projector(PyObject *mod, PyObject *args, PyObject *kwd
     int dual = 0;
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!O!|p",
                                      (char *const[]){"form_orders", "basis_in", "space_out", "dual", NULL},
-                                     &element_form_spec_type, &form_specs, state->type_basis2d, &basis_in,
+                                     state->type_form_spec, &form_specs, state->type_basis2d, &basis_in,
                                      state->type_fem_space, &space_out, &dual))
     {
         return NULL;

--- a/src/evaluation/forms.c
+++ b/src/evaluation/forms.c
@@ -80,6 +80,7 @@ typedef struct
 
 static void element_form_spec_iter_dealloc(element_form_spec_iter_t *it)
 {
+    PyObject_GC_UnTrack(it);
     Py_XDECREF(it->efs);
     Py_TYPE(it)->tp_free((PyObject *)it);
 }
@@ -111,6 +112,7 @@ static PyType_Slot element_form_spec_iter_type_slots[] = {
     {.slot = Py_tp_dealloc, .pfunc = element_form_spec_iter_dealloc},
     {.slot = Py_tp_iter, .pfunc = PyObject_SelfIter},
     {.slot = Py_tp_iternext, .pfunc = element_form_spec_iter_next},
+    {.slot = Py_tp_traverse, .pfunc = traverse_heap_type},
     {}, // sentinel
 };
 
@@ -118,7 +120,7 @@ PyType_Spec element_form_spec_iter_type_spec = {
     .name = "mfv2d._mfv2d._ElementFormSpecificationIter",
     .basicsize = sizeof(element_form_spec_iter_t),
     .itemsize = 0,
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HAVE_GC,
     .slots = element_form_spec_iter_type_slots,
 };
 
@@ -231,6 +233,7 @@ static PyObject *element_form_spec_new(PyTypeObject *type, PyObject *args, const
 
 static void element_form_spec_dealloc(element_form_spec_t *this)
 {
+    PyObject_GC_UnTrack(this);
     Py_TYPE(this)->tp_free((PyObject *)this);
 }
 
@@ -866,6 +869,7 @@ static PyType_Slot element_form_spec_slots[] = {
     {.slot = Py_sq_length, .pfunc = element_form_spec_len},
     {.slot = Py_sq_contains, .pfunc = element_form_spec_contains},
     {.slot = Py_tp_iter, .pfunc = element_form_spec_iter},
+    {.slot = Py_tp_traverse, .pfunc = traverse_heap_type},
     {}, // sentinel
 };
 
@@ -873,6 +877,6 @@ PyType_Spec element_form_spec_type_spec = {
     .name = "mfv2d._mfv2d._ElementFormSpecification",
     .basicsize = sizeof(element_form_spec_t),
     .itemsize = sizeof(form_spec_t),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_HAVE_GC,
     .slots = element_form_spec_slots,
 };

--- a/src/evaluation/forms.c
+++ b/src/evaluation/forms.c
@@ -86,7 +86,7 @@ static void element_form_spec_iter_dealloc(element_form_spec_iter_t *it)
 
 static PyObject *element_form_spec_iter_next(element_form_spec_iter_t *it)
 {
-    const mfv2d_module_state_t *const state = PyType_GetModuleState(Py_TYPE(it));
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(it));
     if (!state)
         return NULL;
 

--- a/src/evaluation/forms.c
+++ b/src/evaluation/forms.c
@@ -11,7 +11,7 @@ static const char *form_order_str_table[] = {
     [FORM_ORDER_2] = "FORM_ORDER_2",
 };
 
-const char *form_order_str(form_order_t order)
+const char *form_order_str(const form_order_t order)
 {
     // ALWAYS RANGE CHECK!
     if (order < FORM_ORDER_UNKNOWN || order > FORM_ORDER_2)
@@ -86,6 +86,17 @@ static void element_form_spec_iter_dealloc(element_form_spec_iter_t *it)
 
 static PyObject *element_form_spec_iter_next(element_form_spec_iter_t *it)
 {
+    const mfv2d_module_state_t *const state = PyType_GetModuleState(Py_TYPE(it));
+    if (!state)
+        return NULL;
+
+    if (!PyObject_TypeCheck(it, state->type_form_spec_iter))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_form_spec_iter->tp_name,
+                     Py_TYPE(it)->tp_name);
+        return NULL;
+    }
+
     if (it->index >= Py_SIZE(it->efs))
     {
         PyErr_SetNone(PyExc_StopIteration);
@@ -95,16 +106,6 @@ static PyObject *element_form_spec_iter_next(element_form_spec_iter_t *it)
     it->index += 1;
     return Py_BuildValue("si", it->efs->forms[i].name, it->efs->forms[i].order);
 }
-
-// MFV2D_INTERNAL
-// PyTypeObject element_form_spec_iter_type = {
-//     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "mfv2d._mfv2d._ElementFormSpecificationIter",
-//     .tp_basicsize = sizeof(element_form_spec_iter_t),
-//     .tp_dealloc = (destructor)element_form_spec_iter_dealloc,
-//     .tp_flags = Py_TPFLAGS_DEFAULT,
-//     .tp_iter = PyObject_SelfIter, // the iterator's __iter__ returns self
-//     .tp_iternext = (iternextfunc)element_form_spec_iter_next,
-// };
 
 static PyType_Slot element_form_spec_iter_type_slots[] = {
     {.slot = Py_tp_dealloc, .pfunc = element_form_spec_iter_dealloc},
@@ -123,11 +124,17 @@ PyType_Spec element_form_spec_iter_type_spec = {
 
 static PyObject *element_form_spec_iter(element_form_spec_t *self)
 {
-    // NOTE: until PyType_GetModuleByDef is in the stable API, this may be tricky.
-    const mfv2d_module_state_t *const state = PyType_GetModuleState(Py_TYPE(self));
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
     if (!state)
         return NULL;
-    element_form_spec_iter_t *const it = PyObject_New(element_form_spec_iter_t, state->type_form_spec_iter);
+    if (!PyObject_TypeCheck(self, state->type_form_spec))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_form_spec->tp_name, Py_TYPE(self)->tp_name);
+        return NULL;
+    }
+
+    element_form_spec_iter_t *const it =
+        (element_form_spec_iter_t *)state->type_form_spec_iter->tp_alloc(state->type_form_spec_iter, 0);
     if (!it)
     {
         return NULL;
@@ -138,7 +145,7 @@ static PyObject *element_form_spec_iter(element_form_spec_t *self)
     return (PyObject *)it;
 }
 
-static PyObject *element_form_spec_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+static PyObject *element_form_spec_new(PyTypeObject *type, PyObject *args, const PyObject *kwds)
 {
     const Py_ssize_t num_specs = PyTuple_GET_SIZE(args);
     if (num_specs == 0)
@@ -267,6 +274,16 @@ static PyObject *element_form_spec_get_names(const element_form_spec_t *self, vo
 
 static PyObject *element_form_spec_getitem(const element_form_spec_t *self, const Py_ssize_t index)
 {
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
+    if (!state)
+        return NULL;
+
+    if (!PyObject_TypeCheck(self, state->type_form_spec))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_form_spec->tp_name, Py_TYPE(self)->tp_name);
+        return NULL;
+    }
+
     if (index < 0 || index >= Py_SIZE(self))
     {
         PyErr_SetString(PyExc_IndexError, "Index out of range");
@@ -277,11 +294,31 @@ static PyObject *element_form_spec_getitem(const element_form_spec_t *self, cons
 
 static Py_ssize_t element_form_spec_len(const element_form_spec_t *self)
 {
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
+    if (!state)
+        return -1;
+
+    if (!PyObject_TypeCheck(self, state->type_form_spec))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_form_spec->tp_name, Py_TYPE(self)->tp_name);
+        return -1;
+    }
+
     return Py_SIZE(self);
 }
 
 static int element_form_spec_contains(const element_form_spec_t *self, PyObject *item)
 {
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
+    if (!state)
+        return -1;
+
+    if (!PyObject_TypeCheck(self, state->type_form_spec))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_form_spec->tp_name, Py_TYPE(self)->tp_name);
+        return -1;
+    }
+
     if (!PyTuple_Check(item) || PyTuple_GET_SIZE(item) != 2)
     {
         PyErr_SetString(PyExc_TypeError, "Each spec must be a (name, order) tuple");
@@ -326,12 +363,6 @@ static int element_form_spec_contains(const element_form_spec_t *self, PyObject 
     return 0;
 }
 
-// static PySequenceMethods element_form_spec_sequence_methods = {
-//     .sq_item = (ssizeargfunc)element_form_spec_getitem,
-//     .sq_length = (lenfunc)element_form_spec_len,
-//     .sq_contains = (objobjproc)element_form_spec_contains,
-// };
-
 static PyGetSetDef element_form_spec_getset[] = {
     {
         .name = "orders",
@@ -349,13 +380,24 @@ static PyGetSetDef element_form_spec_getset[] = {
 
 static PyObject *element_form_spec_repr(const element_form_spec_t *self)
 {
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
+    if (!state)
+        return NULL;
+
+    if (!PyObject_TypeCheck(self, state->type_form_spec))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_form_spec->tp_name, Py_TYPE(self)->tp_name);
+        return NULL;
+    }
+
     const Py_ssize_t size = Py_SIZE(self);
     PyObject *res = PyUnicode_FromString("_ElementFormSpecification(");
     if (!res)
         return NULL;
     for (Py_ssize_t i = 0; i < size; ++i)
     {
-        PyObject *val = PyUnicode_FromFormat("%s(%u)", self->forms[i].name, self->forms[i].order);
+        const char *const ending = i == size - 1 ? ")" : ", ";
+        PyObject *val = PyUnicode_FromFormat("%s(%u)%s", self->forms[i].name, self->forms[i].order, ending);
         if (!val)
         {
             Py_DECREF(res);
@@ -377,6 +419,16 @@ static PyObject *element_form_spec_repr(const element_form_spec_t *self)
 
 static PyObject *element_form_spec_str(const element_form_spec_t *self)
 {
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
+    if (!state)
+        return NULL;
+
+    if (!PyObject_TypeCheck(self, state->type_form_spec))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_form_spec->tp_name, Py_TYPE(self)->tp_name);
+        return NULL;
+    }
+
     const Py_ssize_t size = Py_SIZE(self);
     PyObject *res = PyUnicode_FromString("(");
     if (!res)
@@ -399,12 +451,28 @@ static PyObject *element_form_spec_str(const element_form_spec_t *self)
     return new;
 }
 
-static PyObject *element_form_spec_form_offset(const element_form_spec_t *self, PyObject *args, PyObject *kwds)
+static PyObject *element_form_spec_form_offset(PyObject *self, PyTypeObject *defining_type, PyObject *const *args,
+                                               const Py_ssize_t nargs, const PyObject *kwnames)
 {
-    long index, order_1, order_2;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "lll", (char *[4]){"", "order_1", "order_2", NULL}, &index, &order_1,
-                                     &order_2))
+    Py_ssize_t index, order_1, order_2;
+
+    if (parse_arguments_check((argument_t[]){{.type = ARG_TYPE_INT, .p_val = &index},
+                                             {.type = ARG_TYPE_INT, .p_val = &order_1, .kwname = "order_1"},
+                                             {.type = ARG_TYPE_INT, .p_val = &order_2, .kwname = "order_2"},
+                                             {}},
+                              args, nargs, kwnames) < 0)
         return NULL;
+
+    const mfv2d_module_state_t *const state = PyType_GetModuleState(defining_type);
+    if (!state)
+        return NULL;
+
+    if (!PyObject_TypeCheck(self, state->type_form_spec))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_form_spec->tp_name, Py_TYPE(self)->tp_name);
+        return NULL;
+    }
+
     if (index < 0 || index >= Py_SIZE(self))
     {
         PyErr_SetString(PyExc_IndexError, "Index out of range");
@@ -416,7 +484,7 @@ static PyObject *element_form_spec_form_offset(const element_form_spec_t *self, 
         return NULL;
     }
 
-    return PyLong_FromLong(element_form_offset(self, index, order_1, order_2));
+    return PyLong_FromLong(element_form_offset((const element_form_spec_t *)self, index, order_1, order_2));
 }
 
 PyDoc_STRVAR(element_form_spec_form_order_docstr,
@@ -439,12 +507,28 @@ PyDoc_STRVAR(element_form_spec_form_order_docstr,
              "int\n"
              "    Offset of degrees of freedom of the differential form.\n");
 
-static PyObject *element_form_spec_form_size(const element_form_spec_t *const self, PyObject *args, PyObject *kwds)
+static PyObject *element_form_spec_form_size(element_form_spec_t *self, PyTypeObject *defining_type,
+                                             PyObject *const *args, const Py_ssize_t nargs, const PyObject *kwnames)
 {
-    long index, order_1, order_2;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "lll", (char *[4]){"", "order_1", "order_2", NULL}, &index, &order_1,
-                                     &order_2))
+    Py_ssize_t index, order_1, order_2;
+
+    if (parse_arguments_check((argument_t[]){{.type = ARG_TYPE_INT, .p_val = &index},
+                                             {.type = ARG_TYPE_INT, .p_val = &order_1, .kwname = "order_1"},
+                                             {.type = ARG_TYPE_INT, .p_val = &order_2, .kwname = "order_2"},
+                                             {}},
+                              args, nargs, kwnames) < 0)
         return NULL;
+
+    const mfv2d_module_state_t *const state = PyType_GetModuleState(defining_type);
+    if (!state)
+        return NULL;
+
+    if (!PyObject_TypeCheck(self, state->type_form_spec))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_form_spec->tp_name, Py_TYPE(self)->tp_name);
+        return NULL;
+    }
+
     if (index < 0 || index >= Py_SIZE(self))
     {
         PyErr_SetString(PyExc_IndexError, "Index out of range");
@@ -477,22 +561,32 @@ PyDoc_STRVAR(element_form_spec_form_size_docstr,
              "int\n"
              "    Number of degrees of freedom of the differential form.\n");
 
-static PyObject *element_form_spec_form_total_size(const element_form_spec_t *const self, PyObject *args,
-                                                   PyObject *kwds)
+static PyObject *element_form_spec_form_total_size(const element_form_spec_t *self, PyTypeObject *defining_type,
+                                                   PyObject *const *args, const Py_ssize_t nargs,
+                                                   const PyObject *kwnames)
 {
-    long order_1, order_2;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "ll", (char *[3]){"order_1", "order_2", NULL}, &order_1, &order_2))
+    Py_ssize_t order_1, order_2;
+    if (parse_arguments_check((argument_t[]){{.type = ARG_TYPE_INT, .p_val = &order_1, .kwname = "order_1"},
+                                             {.type = ARG_TYPE_INT, .p_val = &order_2, .kwname = "order_2"},
+                                             {}},
+                              args, nargs, kwnames) < 0)
         return NULL;
+
+    const mfv2d_module_state_t *const state = PyType_GetModuleState(defining_type);
+    if (!state)
+        return NULL;
+
+    if (!PyObject_TypeCheck(self, state->type_form_spec))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_form_spec->tp_name, Py_TYPE(self)->tp_name);
+        return NULL;
+    }
+
     if (order_1 <= 0 || order_2 <= 0)
     {
         PyErr_Format(PyExc_ValueError, "Orders must be positive, but (%ld, %ld) were given", order_1, order_2);
         return NULL;
     }
-    // unsigned size = 0;
-    // for (unsigned i = 0; i < Py_SIZE(self); ++i)
-    // {
-    //     size += form_degrees_of_freedom_count(self->forms[i].order, order_1, order_2);
-    // }
 
     return PyLong_FromLong(element_form_specs_total_count(self, order_1, order_2));
 }
@@ -517,16 +611,27 @@ PyDoc_STRVAR(element_form_spec_size_total_docstr,
              "int\n"
              "    Total number of degrees of freedom of all differential forms.\n");
 
-static PyObject *element_form_spec_form_orders(const element_form_spec_t *self, PyObject *args, PyObject *kwds)
+static PyObject *element_form_spec_form_orders(const element_form_spec_t *self, PyTypeObject *defining_type,
+                                               PyObject *const *args, const Py_ssize_t nargs, const PyObject *kwnames)
 {
-    long order_1, order_2;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "ll", (char *[3]){"order_1", "order_2", NULL}, &order_1, &order_2))
+    Py_ssize_t order_1, order_2;
+
+    if (parse_arguments_check((argument_t[]){{.type = ARG_TYPE_INT, .p_val = &order_1, .kwname = "order_1"},
+                                             {.type = ARG_TYPE_INT, .p_val = &order_2, .kwname = "order_2"},
+                                             {}},
+                              args, nargs, kwnames) < 0)
         return NULL;
-    if (order_1 <= 0 || order_2 <= 0)
+
+    const mfv2d_module_state_t *const state = PyType_GetModuleState(defining_type);
+    if (!state)
+        return NULL;
+
+    if (!PyObject_TypeCheck(self, state->type_form_spec))
     {
-        PyErr_Format(PyExc_ValueError, "Orders must be positive, but (%ld, %ld) were given", order_1, order_2);
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_form_spec->tp_name, Py_TYPE(self)->tp_name);
         return NULL;
     }
+
     PyObject *res = PyTuple_New(Py_SIZE(self) + 1);
     if (!res)
         return NULL;
@@ -571,11 +676,27 @@ PyDoc_STRVAR(element_form_spec_form_orders_docstr,
              "    Offsets of degrees of freedom for all differential forms, with an extra\n"
              "    entry at the end, which is the count of all degrees of freedom.\n");
 
-static PyObject *element_form_spec_form_sizes(const element_form_spec_t *this, PyObject *args, PyObject *kwds)
+static PyObject *element_form_spec_form_sizes(const element_form_spec_t *this, PyTypeObject *defining_type,
+                                              PyObject *const *args, const Py_ssize_t nargs, const PyObject *kwnames)
 {
-    long order_1, order_2;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "ll", (char *[3]){"order_1", "order_2", NULL}, &order_1, &order_2))
+    Py_ssize_t order_1, order_2;
+
+    if (parse_arguments_check((argument_t[]){{.type = ARG_TYPE_INT, .p_val = &order_1, .kwname = "order_1"},
+                                             {.type = ARG_TYPE_INT, .p_val = &order_2, .kwname = "order_2"},
+                                             {}},
+                              args, nargs, kwnames) < 0)
         return NULL;
+
+    const mfv2d_module_state_t *const state = PyType_GetModuleState(defining_type);
+    if (!state)
+        return NULL;
+
+    if (!PyObject_TypeCheck(this, state->type_form_spec))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_form_spec->tp_name, Py_TYPE(this)->tp_name);
+        return NULL;
+    }
+
     if (order_1 <= 0 || order_2 <= 0)
     {
         PyErr_Format(PyExc_ValueError, "Orders must be positive, but (%ld, %ld) were given", order_1, order_2);
@@ -614,8 +735,25 @@ PyDoc_STRVAR(element_form_spec_form_sizes_docstr, "form_sizes(order_1: int, orde
                                                   "tuple of int\n"
                                                   "    Number of degrees of freedom for each differential form.\n");
 
-static PyObject *element_form_spec_get_index(const element_form_spec_t *this, PyObject *arg)
+static PyObject *element_form_spec_get_index(const element_form_spec_t *this, PyTypeObject *defining_type,
+                                             PyObject *const *args, const Py_ssize_t nargs, const PyObject *kwnames)
 {
+    PyTupleObject *arg;
+    if (parse_arguments_check(
+            (argument_t[]){{.type = ARG_TYPE_PYTHON, .p_val = (void *)&arg, .type_check = &PyTuple_Type}, {}}, args,
+            nargs, kwnames) < 0)
+        return NULL;
+
+    const mfv2d_module_state_t *const state = PyType_GetModuleState(defining_type);
+    if (!state)
+        return NULL;
+
+    if (!PyObject_TypeCheck(this, state->type_form_spec))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_form_spec->tp_name, Py_TYPE(this)->tp_name);
+        return NULL;
+    }
+
     if (!PyTuple_Check(arg) || PyTuple_GET_SIZE(arg) != 2)
     {
         PyErr_Format(PyExc_TypeError, "Expected a tuple of (name, order) but got %R", arg);
@@ -670,37 +808,37 @@ static PyMethodDef element_form_spec_methods[] = {
     {
         .ml_name = "form_offset",
         .ml_meth = (void *)element_form_spec_form_offset,
-        .ml_flags = METH_VARARGS | METH_KEYWORDS,
+        .ml_flags = METH_FASTCALL | METH_KEYWORDS | METH_METHOD,
         .ml_doc = element_form_spec_form_order_docstr,
     },
     {
         .ml_name = "form_size",
         .ml_meth = (void *)element_form_spec_form_size,
-        .ml_flags = METH_VARARGS | METH_KEYWORDS,
+        .ml_flags = METH_FASTCALL | METH_KEYWORDS | METH_METHOD,
         .ml_doc = element_form_spec_form_size_docstr,
     },
     {
         .ml_name = "total_size",
         .ml_meth = (void *)element_form_spec_form_total_size,
-        .ml_flags = METH_VARARGS | METH_KEYWORDS,
+        .ml_flags = METH_FASTCALL | METH_KEYWORDS | METH_METHOD,
         .ml_doc = element_form_spec_size_total_docstr,
     },
     {
         .ml_name = "form_offsets",
         .ml_meth = (void *)element_form_spec_form_orders,
-        .ml_flags = METH_VARARGS | METH_KEYWORDS,
+        .ml_flags = METH_FASTCALL | METH_KEYWORDS | METH_METHOD,
         .ml_doc = element_form_spec_form_orders_docstr,
     },
     {
         .ml_name = "form_sizes",
         .ml_meth = (void *)element_form_spec_form_sizes,
-        .ml_flags = METH_VARARGS | METH_KEYWORDS,
+        .ml_flags = METH_FASTCALL | METH_KEYWORDS | METH_METHOD,
         .ml_doc = element_form_spec_form_sizes_docstr,
     },
     {
         .ml_name = "index",
         .ml_meth = (void *)element_form_spec_get_index,
-        .ml_flags = METH_O,
+        .ml_flags = METH_FASTCALL | METH_KEYWORDS | METH_METHOD,
         .ml_doc = element_form_spec_get_index_docstr,
     },
     {},
@@ -715,22 +853,6 @@ PyDoc_STRVAR(element_form_spec_docstr, "_ElementFormSpecification(*specs: tuple[
                                        "    Specifications for differential forms on the element. Each label must be\n"
                                        "    unique and order have a valid value which is in\n"
                                        "    :class:`mfv2d.kform.UnknownFormOrder`.\n");
-
-// PyTypeObject element_form_spec_type = {
-//     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "mfv2d._mfv2d._ElementFormSpecification",
-//     .tp_basicsize = sizeof(element_form_spec_t),
-//     .tp_itemsize = sizeof(form_spec_t),
-//     .tp_dealloc = (destructor)element_form_spec_dealloc,
-//     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-//     .tp_doc = element_form_spec_docstr,
-//     .tp_new = element_form_spec_new,
-//     .tp_getset = element_form_spec_getset,
-//     .tp_as_sequence = &element_form_spec_sequence_methods,
-//     .tp_repr = (reprfunc)element_form_spec_repr,
-//     .tp_str = (reprfunc)element_form_spec_str,
-//     .tp_methods = element_form_spec_methods,
-//     .tp_iter = (getiterfunc)element_form_spec_iter,
-// };
 
 static PyType_Slot element_form_spec_slots[] = {
     {.slot = Py_tp_dealloc, .pfunc = element_form_spec_dealloc},

--- a/src/evaluation/forms.h
+++ b/src/evaluation/forms.h
@@ -39,15 +39,17 @@ typedef struct
 } element_form_spec_t;
 
 MFV2D_INTERNAL
-extern PyTypeObject element_form_spec_type;
+// extern PyTypeObject element_form_spec_type;
+extern PyType_Spec element_form_spec_type_spec;
 
 MFV2D_INTERNAL
-extern PyTypeObject element_form_spec_iter_type;
+// extern PyTypeObject element_form_spec_iter_type;
+extern PyType_Spec element_form_spec_iter_type_spec;
 
 MFV2D_INTERNAL
-unsigned element_form_offset(const element_form_spec_t *const spec, unsigned index, unsigned order_1, unsigned order_2);
+unsigned element_form_offset(const element_form_spec_t *spec, unsigned index, unsigned order_1, unsigned order_2);
 
 MFV2D_INTERNAL
-unsigned element_form_specs_total_count(const element_form_spec_t *const spec, unsigned order_1, unsigned order_2);
+unsigned element_form_specs_total_count(const element_form_spec_t *spec, unsigned order_1, unsigned order_2);
 
 #endif // FORMS_H

--- a/src/evaluation/integrating_fields.c
+++ b/src/evaluation/integrating_fields.c
@@ -352,8 +352,12 @@ void reconstruct_field_2_form(const fem_space_2d_t *space, const double degrees_
 }
 
 MFV2D_INTERNAL
-PyObject *compute_integrating_fields(PyObject *Py_UNUSED(self), PyObject *args, PyObject *kwds)
+PyObject *compute_integrating_fields(PyObject *mod, PyObject *args, PyObject *kwds)
 {
+    const mfv2d_module_state_t *const state = PyModule_GetState(mod);
+    if (!state)
+        return NULL;
+
     element_fem_space_2d_t *element_space;
     element_form_spec_t *form_specs;
     PyObject *py_field_orders;
@@ -362,7 +366,7 @@ PyObject *compute_integrating_fields(PyObject *Py_UNUSED(self), PyObject *args, 
     if (!PyArg_ParseTupleAndKeywords(
             args, kwds, "O!O!O!O!O!",
             (char *[6]){"fem_space", "form_specs", "field_orders", "field_information", "degrees_of_freedom", NULL},
-            &element_fem_space_2d_type, &element_space, &element_form_spec_type, &form_specs, &PyTuple_Type,
+            state->type_fem_space, &element_space, &element_form_spec_type, &form_specs, &PyTuple_Type,
             &py_field_orders, &PyTuple_Type, &field_information, &PyArray_Type, &degrees_of_freedom))
     {
         return NULL;

--- a/src/evaluation/integrating_fields.c
+++ b/src/evaluation/integrating_fields.c
@@ -366,8 +366,8 @@ PyObject *compute_integrating_fields(PyObject *mod, PyObject *args, PyObject *kw
     if (!PyArg_ParseTupleAndKeywords(
             args, kwds, "O!O!O!O!O!",
             (char *[6]){"fem_space", "form_specs", "field_orders", "field_information", "degrees_of_freedom", NULL},
-            state->type_fem_space, &element_space, &element_form_spec_type, &form_specs, &PyTuple_Type,
-            &py_field_orders, &PyTuple_Type, &field_information, &PyArray_Type, &degrees_of_freedom))
+            state->type_fem_space, &element_space, state->type_form_spec, &form_specs, &PyTuple_Type, &py_field_orders,
+            &PyTuple_Type, &field_information, &PyArray_Type, &degrees_of_freedom))
     {
         return NULL;
     }

--- a/src/fem_space/basis.c
+++ b/src/fem_space/basis.c
@@ -94,10 +94,13 @@ static mfv2d_result_t compute_nodal_and_edge_values(integration_rule_1d_t *rule,
 }
 static PyObject *basis_1d_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
+    const mfv2d_module_state_t *state = PyType_GetModuleState(type);
+    if (!state)
+        return NULL;
     integration_rule_1d_t *rule;
     int order;
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "iO!", (char *const[3]){"order", "rule", NULL}, &order,
-                                     &integration_rule_1d_type, &rule))
+                                     state->type_int_rule, &rule))
         return NULL;
 
     if (order <= 0)
@@ -207,33 +210,43 @@ static PyObject *basis_1d_get_integration_rule(const basis_1d_t *self, void *Py_
     return (PyObject *)self->integration_rule;
 }
 
-static PyGetSetDef basis_1d_getsets[] = {{.name = "order",
-                                          .get = (getter)basis_1d_get_order,
-                                          .set = NULL,
-                                          .doc = "int : Order of the basis.",
-                                          .closure = NULL},
-                                         {.name = "node",
-                                          .get = (getter)basis_1d_get_nodal,
-                                          .set = NULL,
-                                          .doc = "array : Nodal basis values.",
-                                          .closure = NULL},
-                                         {.name = "edge",
-                                          .get = (getter)basis_1d_get_edge,
-                                          .set = NULL,
-                                          .doc = "array : Edge basis values.",
-                                          .closure = NULL},
-                                         {.name = "rule",
-                                          .get = (getter)basis_1d_get_integration_rule,
-                                          .set = NULL,
-                                          .doc = "IntegrationRule1D : integration rule used",
-                                          .closure = NULL},
-                                         {
-                                             .name = "roots",
-                                             .get = (getter)basis_1d_get_roots,
-                                             .set = NULL,
-                                             .doc = "array : Roots of the nodal basis.",
-                                         },
-                                         {NULL}};
+static PyGetSetDef basis_1d_getsets[] = {
+    {
+        .name = "order",
+        .get = (getter)basis_1d_get_order,
+        .set = NULL,
+        .doc = "int : Order of the basis.",
+        .closure = NULL,
+    },
+    {
+        .name = "node",
+        .get = (getter)basis_1d_get_nodal,
+        .set = NULL,
+        .doc = "array : Nodal basis values.",
+        .closure = NULL,
+    },
+    {
+        .name = "edge",
+        .get = (getter)basis_1d_get_edge,
+        .set = NULL,
+        .doc = "array : Edge basis values.",
+        .closure = NULL,
+    },
+    {
+        .name = "rule",
+        .get = (getter)basis_1d_get_integration_rule,
+        .set = NULL,
+        .doc = "IntegrationRule1D : integration rule used",
+        .closure = NULL,
+    },
+    {
+        .name = "roots",
+        .get = (getter)basis_1d_get_roots,
+        .set = NULL,
+        .doc = "array : Roots of the nodal basis.",
+    },
+    {},
+};
 
 PyDoc_STRVAR(basis_1d_doc, "Basis1D(order: int, rule: IntegrationRule1D)\n"
                            "One-dimensional basis functions collection used for FEM space creation.\n"
@@ -286,16 +299,32 @@ PyDoc_STRVAR(basis_1d_doc, "Basis1D(order: int, rule: IntegrationRule1D)\n"
                            "    >>> plt.show()\n"
                            "\n");
 
-PyTypeObject basis_1d_type = {
-    .tp_new = basis_1d_new,
-    .tp_dealloc = (destructor)basis_1d_dealloc,
-    .tp_repr = (reprfunc)basis_1d_repr,
-    .tp_getset = basis_1d_getsets,
-    .tp_name = "mfv2d._mfv2d.Basis1D",
-    .tp_basicsize = sizeof(basis_1d_t),
-    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE,
-    .tp_doc = basis_1d_doc,
-    .tp_itemsize = 0,
+// PyTypeObject basis_1d_type = {
+//     .tp_new = basis_1d_new,
+//     .tp_dealloc = (destructor)basis_1d_dealloc,
+//     .tp_repr = (reprfunc)basis_1d_repr,
+//     .tp_getset = basis_1d_getsets,
+//     .tp_name = "mfv2d._mfv2d.Basis1D",
+//     .tp_basicsize = sizeof(basis_1d_t),
+//     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE,
+//     .tp_doc = basis_1d_doc,
+//     .tp_itemsize = 0,
+// };
+
+static PyType_Slot basis_1d_slots[] = {
+    {.slot = Py_tp_new, .pfunc = basis_1d_new},
+    {.slot = Py_tp_repr, .pfunc = basis_1d_repr},
+    {.slot = Py_tp_getset, .pfunc = basis_1d_getsets},
+    {.slot = Py_tp_doc, .pfunc = (void *)basis_1d_doc},
+    {}, // sentinel
+};
+
+PyType_Spec basis_1d_type_spec = {
+    .name = "mfv2d._mfv2d.Basis1D",
+    .basicsize = sizeof(basis_1d_t),
+    .itemsize = 0,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HEAPTYPE,
+    .slots = basis_1d_slots,
 };
 
 MFV2D_INTERNAL
@@ -316,10 +345,14 @@ basis_2d_t *create_basis_2d_object(PyTypeObject *type, basis_1d_t *basis_xi, bas
 // __new__ method
 static PyObject *basis_2d_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
+    const mfv2d_module_state_t *state = PyType_GetModuleState(type);
+    if (!state)
+        return NULL;
     basis_1d_t *basis_xi = NULL, *basis_eta = NULL;
     static char *kwlist[] = {"basis_xi", "basis_eta", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!", kwlist, &basis_1d_type, &basis_xi, &basis_1d_type, &basis_eta))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!", kwlist, state->type_basis1d, &basis_xi, state->type_basis1d,
+                                     &basis_eta))
         return NULL;
 
     basis_2d_t *const self = create_basis_2d_object(type, basis_xi, basis_eta);
@@ -371,7 +404,7 @@ static PyObject *basis_2d_get_order_2(const basis_2d_t *self, void *Py_UNUSED(cl
     return PyLong_FromLong(self->basis_eta->order);
 }
 
-static PyGetSetDef Basis2D_getset[] = {
+static PyGetSetDef basis_2d_getset[] = {
     {
         "basis_xi",
         (getter)basis_2d_get_basis_xi,
@@ -414,7 +447,7 @@ static PyGetSetDef Basis2D_getset[] = {
         .doc = "int : Order of the basis in the second dimension.",
         .closure = NULL,
     },
-    {NULL} // Sentinel
+    {} // Sentinel
 };
 
 PyDoc_STRVAR(basis_2d_type_docstring,
@@ -429,6 +462,23 @@ PyTypeObject basis_2d_type = {
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_new = basis_2d_new,
     .tp_repr = (reprfunc)basis_2d_repr,
-    .tp_getset = Basis2D_getset,
+    .tp_getset = basis_2d_getset,
     .tp_doc = basis_2d_type_docstring,
+};
+
+static PyType_Slot basis_2d_slots[] = {
+    {.slot = Py_tp_dealloc, .pfunc = basis_2d_dealloc},
+    {.slot = Py_tp_new, .pfunc = basis_2d_new},
+    {.slot = Py_tp_repr, .pfunc = basis_2d_repr},
+    {.slot = Py_tp_getset, .pfunc = basis_2d_getset},
+    {.slot = Py_tp_doc, .pfunc = (void *)basis_2d_type_docstring},
+    {}, // sentinel
+};
+
+PyType_Spec basis_2d_type_spec = {
+    .name = "mfv2d._mfv2d.Basis2D",
+    .basicsize = sizeof(basis_2d_t),
+    .itemsize = 0,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .slots = basis_2d_slots,
 };

--- a/src/fem_space/basis.c
+++ b/src/fem_space/basis.c
@@ -316,6 +316,7 @@ static PyType_Slot basis_1d_slots[] = {
     {.slot = Py_tp_repr, .pfunc = basis_1d_repr},
     {.slot = Py_tp_getset, .pfunc = basis_1d_getsets},
     {.slot = Py_tp_doc, .pfunc = (void *)basis_1d_doc},
+    {.slot = Py_tp_dealloc, .pfunc = (void *)basis_1d_dealloc},
     {}, // sentinel
 };
 

--- a/src/fem_space/basis.c
+++ b/src/fem_space/basis.c
@@ -146,7 +146,7 @@ static void basis_1d_dealloc(basis_1d_t *self)
 
 static PyObject *basis_1d_repr(const basis_1d_t *self)
 {
-    const mfv2d_module_state_t *state = PyType_GetModuleState(Py_TYPE(self));
+    const mfv2d_module_state_t *state = mfv2d_state_from_type(Py_TYPE(self));
     if (!state)
         return NULL;
     if (!PyObject_TypeCheck(self, state->type_basis1d))
@@ -361,7 +361,7 @@ static PyObject *basis_2d_new(PyTypeObject *type, PyObject *args, PyObject *kwds
 // __repr__ method
 static PyObject *basis_2d_repr(const basis_2d_t *self)
 {
-    const mfv2d_module_state_t *state = PyType_GetModuleState(Py_TYPE(self));
+    const mfv2d_module_state_t *state = mfv2d_state_from_type(Py_TYPE(self));
     if (!state)
         return NULL;
     if (!PyObject_TypeCheck(self, state->type_basis2d))

--- a/src/fem_space/basis.c
+++ b/src/fem_space/basis.c
@@ -137,6 +137,7 @@ static PyObject *basis_1d_new(PyTypeObject *type, PyObject *args, PyObject *kwds
 
 static void basis_1d_dealloc(basis_1d_t *self)
 {
+    PyObject_GC_UnTrack(self);
     Py_DECREF(self->integration_rule);
     deallocate(&SYSTEM_ALLOCATOR, self->nodal_basis);
     deallocate(&SYSTEM_ALLOCATOR, self->edge_basis);
@@ -314,6 +315,7 @@ static PyType_Slot basis_1d_slots[] = {
     {.slot = Py_tp_getset, .pfunc = basis_1d_getsets},
     {.slot = Py_tp_doc, .pfunc = (void *)basis_1d_doc},
     {.slot = Py_tp_dealloc, .pfunc = (void *)basis_1d_dealloc},
+    {.slot = Py_tp_traverse, .pfunc = traverse_heap_type},
     {}, // sentinel
 };
 
@@ -321,7 +323,7 @@ PyType_Spec basis_1d_type_spec = {
     .name = "mfv2d._mfv2d.Basis1D",
     .basicsize = sizeof(basis_1d_t),
     .itemsize = 0,
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HEAPTYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_HAVE_GC,
     .slots = basis_1d_slots,
 };
 
@@ -386,6 +388,7 @@ static PyObject *basis_2d_get_basis_eta(const basis_2d_t *self, void *Py_UNUSED(
 
 static void basis_2d_dealloc(basis_2d_t *self)
 {
+    PyObject_GC_UnTrack(self);
     Py_XDECREF(self->basis_xi);
     Py_XDECREF(self->basis_eta);
     Py_TYPE(self)->tp_free((PyObject *)self);
@@ -479,6 +482,7 @@ static PyType_Slot basis_2d_slots[] = {
     {.slot = Py_tp_repr, .pfunc = basis_2d_repr},
     {.slot = Py_tp_getset, .pfunc = basis_2d_getset},
     {.slot = Py_tp_doc, .pfunc = (void *)basis_2d_type_docstring},
+    {.slot = Py_tp_traverse, .pfunc = traverse_heap_type},
     {}, // sentinel
 };
 
@@ -486,6 +490,6 @@ PyType_Spec basis_2d_type_spec = {
     .name = "mfv2d._mfv2d.Basis2D",
     .basicsize = sizeof(basis_2d_t),
     .itemsize = 0,
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HAVE_GC,
     .slots = basis_2d_slots,
 };

--- a/src/fem_space/basis.c
+++ b/src/fem_space/basis.c
@@ -17,7 +17,7 @@ static mfv2d_result_t compute_nodal_and_edge_values(integration_rule_1d_t *rule,
         return MFV2D_FAILED_ALLOC;
     }
 
-    // weights array here is used only as scratch, since they're the side product.
+    // weight array here is used only as scratch, since they're the side product.
     const int non_converged = gauss_lobatto_nodes_weights(order + 1, 1e-15, 10, roots, weights);
     if (non_converged)
     {
@@ -94,7 +94,7 @@ static mfv2d_result_t compute_nodal_and_edge_values(integration_rule_1d_t *rule,
 }
 static PyObject *basis_1d_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
-    const mfv2d_module_state_t *state = PyType_GetModuleState(type);
+    const mfv2d_module_state_t *state = mfv2d_state_from_type(type);
     if (!state)
         return NULL;
     integration_rule_1d_t *rule;
@@ -146,6 +146,15 @@ static void basis_1d_dealloc(basis_1d_t *self)
 
 static PyObject *basis_1d_repr(const basis_1d_t *self)
 {
+    const mfv2d_module_state_t *state = PyType_GetModuleState(Py_TYPE(self));
+    if (!state)
+        return NULL;
+    if (!PyObject_TypeCheck(self, state->type_basis1d))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_basis1d->tp_name, Py_TYPE(self)->tp_name);
+        return NULL;
+    }
+
     char buffer[128];
     (void)snprintf(buffer, sizeof(buffer), "Basis1D(order=%u)", self->order);
     return PyUnicode_FromString(buffer);
@@ -299,18 +308,6 @@ PyDoc_STRVAR(basis_1d_doc, "Basis1D(order: int, rule: IntegrationRule1D)\n"
                            "    >>> plt.show()\n"
                            "\n");
 
-// PyTypeObject basis_1d_type = {
-//     .tp_new = basis_1d_new,
-//     .tp_dealloc = (destructor)basis_1d_dealloc,
-//     .tp_repr = (reprfunc)basis_1d_repr,
-//     .tp_getset = basis_1d_getsets,
-//     .tp_name = "mfv2d._mfv2d.Basis1D",
-//     .tp_basicsize = sizeof(basis_1d_t),
-//     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE,
-//     .tp_doc = basis_1d_doc,
-//     .tp_itemsize = 0,
-// };
-
 static PyType_Slot basis_1d_slots[] = {
     {.slot = Py_tp_new, .pfunc = basis_1d_new},
     {.slot = Py_tp_repr, .pfunc = basis_1d_repr},
@@ -346,7 +343,7 @@ basis_2d_t *create_basis_2d_object(PyTypeObject *type, basis_1d_t *basis_xi, bas
 // __new__ method
 static PyObject *basis_2d_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
-    const mfv2d_module_state_t *state = PyType_GetModuleState(type);
+    const mfv2d_module_state_t *state = mfv2d_state_from_type(type);
     if (!state)
         return NULL;
     basis_1d_t *basis_xi = NULL, *basis_eta = NULL;
@@ -364,6 +361,15 @@ static PyObject *basis_2d_new(PyTypeObject *type, PyObject *args, PyObject *kwds
 // __repr__ method
 static PyObject *basis_2d_repr(const basis_2d_t *self)
 {
+    const mfv2d_module_state_t *state = PyType_GetModuleState(Py_TYPE(self));
+    if (!state)
+        return NULL;
+    if (!PyObject_TypeCheck(self, state->type_basis2d))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_basis2d->tp_name, Py_TYPE(self)->tp_name);
+        return NULL;
+    }
+
     return PyUnicode_FromFormat("Basis2D(basis_xi=%R, basis_eta=%R)", self->basis_xi, self->basis_eta);
 }
 

--- a/src/fem_space/basis.h
+++ b/src/fem_space/basis.h
@@ -15,7 +15,8 @@ typedef struct
 } basis_1d_t;
 
 MFV2D_INTERNAL
-extern PyTypeObject basis_1d_type;
+// extern PyTypeObject basis_1d_type;
+extern PyType_Spec basis_1d_type_spec;
 
 static inline fem_space_1d_t basis_1d_as_fem_space(const basis_1d_t *self)
 {
@@ -37,7 +38,8 @@ typedef struct
 } basis_2d_t;
 
 MFV2D_INTERNAL
-extern PyTypeObject basis_2d_type;
+// extern PyTypeObject basis_2d_type;
+extern PyType_Spec basis_2d_type_spec;
 
 MFV2D_INTERNAL
 basis_2d_t *create_basis_2d_object(PyTypeObject *type, basis_1d_t *basis_xi, basis_1d_t *basis_eta);

--- a/src/fem_space/element_fem_space.c
+++ b/src/fem_space/element_fem_space.c
@@ -330,12 +330,32 @@ static PyGetSetDef element_fem_space_2d_getsets[] = {
     {0}, // Sentilel
 };
 
-static PyObject *element_fem_space_2d_mass_from_order(element_fem_space_2d_t *this, PyObject *args, PyObject *kwargs)
+static PyObject *element_fem_space_2d_mass_from_order(PyObject *self, PyTypeObject *defining_class,
+                                                      PyObject *const *args, const Py_ssize_t nargs,
+                                                      const PyObject *kwnames)
 {
-    int i_order;
+    Py_ssize_t i_order;
     int inverse = 0;
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "i|p", (char *[3]){"order", "inverse", NULL}, &i_order, &inverse))
+    if (parse_arguments_check(
+            (argument_t[]){
+                {.type = ARG_TYPE_INT, .p_val = &i_order, .kwname = "order"},
+                {.type = ARG_TYPE_BOOL, .p_val = &inverse, .kwname = "inverse", .optional = 1},
+                {},
+            },
+            args, nargs, kwnames) < 0)
         return NULL;
+
+    const mfv2d_module_state_t *const state = PyType_GetModuleState(defining_class);
+    if (!state)
+        return NULL;
+
+    if (!PyObject_TypeCheck(self, state->type_fem_space))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_fem_space->tp_name, Py_TYPE(self)->tp_name);
+        return NULL;
+    }
+
+    element_fem_space_2d_t *const this = (element_fem_space_2d_t *)self;
 
     if (i_order <= 0 || i_order > 3)
     {
@@ -385,7 +405,7 @@ static PyMethodDef element_fem_space_2d_methods[] = {
     {
         "mass_from_order",
         (void *)element_fem_space_2d_mass_from_order,
-        METH_VARARGS | METH_KEYWORDS,
+        METH_FASTCALL | METH_KEYWORDS | METH_METHOD,
         mass_from_order_docstr,
     },
     {0}, // Sentinel

--- a/src/fem_space/element_fem_space.c
+++ b/src/fem_space/element_fem_space.c
@@ -94,7 +94,7 @@ static PyObject *element_fem_space_2d_get_mass_surf(element_fem_space_2d_t *self
 
 static PyObject *element_fem_space_2d_get_basis_2d(element_fem_space_2d_t *self, void *Py_UNUSED(closure))
 {
-    const mfv2d_module_state_t *const state = PyType_GetModuleState(Py_TYPE(self));
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
     if (!state)
         return NULL;
     return (PyObject *)create_basis_2d_object(state->type_basis2d, self->basis_xi, self->basis_eta);

--- a/src/fem_space/element_fem_space.c
+++ b/src/fem_space/element_fem_space.c
@@ -19,7 +19,7 @@ static PyObject *element_fem_space_2d_new(PyTypeObject *type, PyObject *args, Py
 {
     basis_2d_t *basis;
     PyArrayObject *corners;
-    const mfv2d_module_state_t *const state = PyType_GetModuleState(type);
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(type);
     if (!state)
         return NULL;
 

--- a/src/fem_space/element_fem_space.c
+++ b/src/fem_space/element_fem_space.c
@@ -3,6 +3,7 @@
 
 static void element_fem_space_2d_dealloc(element_fem_space_2d_t *this)
 {
+    PyObject_GC_UnTrack(this);
     Py_DECREF(this->basis_xi);
     Py_DECREF(this->basis_eta);
     deallocate(&SYSTEM_ALLOCATOR, this->fem_space);
@@ -429,6 +430,7 @@ static PyType_Slot element_fem_space_2d_slots[] = {
     {.slot = Py_tp_dealloc, .pfunc = (void *)element_fem_space_2d_dealloc},
     {.slot = Py_tp_getset, .pfunc = (void *)element_fem_space_2d_getsets},
     {.slot = Py_tp_methods, .pfunc = (void *)element_fem_space_2d_methods},
+    {.slot = Py_tp_traverse, .pfunc = traverse_heap_type},
     {}, // sentinel
 };
 
@@ -436,7 +438,7 @@ PyType_Spec element_fem_space_2d_type_spec = {
     .name = "mfv2d._mfv2d.ElementFemSpace2D",
     .basicsize = sizeof(element_fem_space_2d_t),
     .itemsize = 0,
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HEAPTYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_HAVE_GC,
     .slots = element_fem_space_2d_slots,
 };
 

--- a/src/fem_space/element_fem_space.h
+++ b/src/fem_space/element_fem_space.h
@@ -22,7 +22,8 @@ typedef struct
 } element_fem_space_2d_t;
 
 MFV2D_INTERNAL
-extern PyTypeObject element_fem_space_2d_type;
+// extern PyTypeObject element_fem_space_2d_type;
+extern PyType_Spec element_fem_space_2d_type_spec;
 
 MFV2D_INTERNAL
 const matrix_full_t *element_mass_cache_get_node(element_fem_space_2d_t *cache);

--- a/src/fem_space/integration_rule.c
+++ b/src/fem_space/integration_rule.c
@@ -112,6 +112,15 @@ static PyObject *integration_rule_1d_get_weights(const integration_rule_1d_t *se
 
 static PyObject *integration_rule_1d_repr(const integration_rule_1d_t *self)
 {
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
+    if (!state)
+        return NULL;
+    if (!PyObject_TypeCheck(self, state->type_int_rule))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_int_rule->tp_name, Py_TYPE(self)->tp_name);
+        return NULL;
+    }
+
     char buffer[128];
     (void)snprintf(buffer, sizeof(buffer), "IntegrationRule1D(order=%u)", self->order);
     return PyUnicode_FromString(buffer);

--- a/src/fem_space/integration_rule.c
+++ b/src/fem_space/integration_rule.c
@@ -118,24 +118,31 @@ static PyObject *integration_rule_1d_repr(const integration_rule_1d_t *self)
 }
 
 static PyGetSetDef integration_rule_1d_getset[] = {
-    {.name = "order",
-     .get = (getter)integration_rule_1d_get_order,
-     .set = NULL,
-     .doc = "int : order of the rule",
-     .closure = NULL},
-    {.name = "nodes",
-     .get = (getter)integration_rule_1d_get_nodes,
-     .set = NULL,
-     .doc = "array : Position of integration nodes on the reference domain [-1, +1]\n"
-            "    where the integrated function should be evaluated.\n",
-     .closure = NULL},
-    {.name = "weights",
-     .get = (getter)integration_rule_1d_get_weights,
-     .set = NULL,
-     .doc = "array : Weight values by which the values of evaluated function should be\n"
-            "    multiplied by.\n",
-     .closure = NULL},
-    {NULL}};
+    {
+        .name = "order",
+        .get = (getter)integration_rule_1d_get_order,
+        .set = NULL,
+        .doc = "int : order of the rule",
+        .closure = NULL,
+    },
+    {
+        .name = "nodes",
+        .get = (getter)integration_rule_1d_get_nodes,
+        .set = NULL,
+        .doc = "array : Position of integration nodes on the reference domain [-1, +1]\n"
+               "    where the integrated function should be evaluated.\n",
+        .closure = NULL,
+    },
+    {
+        .name = "weights",
+        .get = (getter)integration_rule_1d_get_weights,
+        .set = NULL,
+        .doc = "array : Weight values by which the values of evaluated function should be\n"
+               "    multiplied by.\n",
+        .closure = NULL,
+    },
+    {}, // sentinel
+};
 
 PyDoc_STRVAR(integration_rule_1d_docstr, "IntegrationRule1D(order: int)\n"
                                          "Type used to contain integration rule information.\n"
@@ -146,13 +153,30 @@ PyDoc_STRVAR(integration_rule_1d_docstr, "IntegrationRule1D(order: int)\n"
                                          "    Order of integration rule used. Can not be negative.\n"
                                          "\n");
 
-PyTypeObject integration_rule_1d_type = {
-    .tp_new = integration_rule_1d_new,
-    .tp_name = "mfv2d._mfv2d.IntegrationRule1D",
-    .tp_basicsize = sizeof(integration_rule_1d_t),
-    .tp_dealloc = (destructor)integration_rule_1d_dealloc,
-    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE,
-    .tp_doc = integration_rule_1d_docstr,
-    .tp_getset = integration_rule_1d_getset,
-    .tp_repr = (reprfunc)integration_rule_1d_repr,
+// PyTypeObject integration_rule_1d_type = {
+//     .tp_new = integration_rule_1d_new,
+//     .tp_name = "mfv2d._mfv2d.IntegrationRule1D",
+//     .tp_basicsize = sizeof(integration_rule_1d_t),
+//     .tp_dealloc = (destructor)integration_rule_1d_dealloc,
+//     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE,
+//     .tp_doc = integration_rule_1d_docstr,
+//     .tp_getset = integration_rule_1d_getset,
+//     .tp_repr = (reprfunc)integration_rule_1d_repr,
+// };
+
+static PyType_Slot integration_rule_1d_slots[] = {
+    {.slot = Py_tp_new, .pfunc = integration_rule_1d_new},
+    {.slot = Py_tp_dealloc, .pfunc = integration_rule_1d_dealloc},
+    {.slot = Py_tp_doc, .pfunc = (void *)integration_rule_1d_docstr},
+    {.slot = Py_tp_getset, .pfunc = integration_rule_1d_getset},
+    {.slot = Py_tp_repr, .pfunc = integration_rule_1d_repr},
+    {}, // sentinel
+};
+
+PyType_Spec integration_rule_1d_type_spec = {
+    .name = "mfv2d._mfv2d.IntegrationRule1D",
+    .basicsize = sizeof(integration_rule_1d_t),
+    .itemsize = 0,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HEAPTYPE,
+    .slots = integration_rule_1d_slots,
 };

--- a/src/fem_space/integration_rule.c
+++ b/src/fem_space/integration_rule.c
@@ -68,6 +68,7 @@ static PyObject *integration_rule_1d_new(PyTypeObject *type, PyObject *args, PyO
 
 static void integration_rule_1d_dealloc(integration_rule_1d_t *self)
 {
+    PyObject_GC_UnTrack(self);
     PyMem_RawFree(self->nodes);
     PyMem_RawFree(self->weights);
     Py_TYPE(self)->tp_free((PyObject *)self);
@@ -179,6 +180,7 @@ static PyType_Slot integration_rule_1d_slots[] = {
     {.slot = Py_tp_doc, .pfunc = (void *)integration_rule_1d_docstr},
     {.slot = Py_tp_getset, .pfunc = integration_rule_1d_getset},
     {.slot = Py_tp_repr, .pfunc = integration_rule_1d_repr},
+    {.slot = Py_tp_traverse, .pfunc = traverse_heap_type},
     {}, // sentinel
 };
 
@@ -186,6 +188,6 @@ PyType_Spec integration_rule_1d_type_spec = {
     .name = "mfv2d._mfv2d.IntegrationRule1D",
     .basicsize = sizeof(integration_rule_1d_t),
     .itemsize = 0,
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HEAPTYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_HAVE_GC,
     .slots = integration_rule_1d_slots,
 };

--- a/src/fem_space/integration_rule.h
+++ b/src/fem_space/integration_rule.h
@@ -15,6 +15,7 @@ typedef struct
 } integration_rule_1d_t;
 
 MFV2D_INTERNAL
-extern PyTypeObject integration_rule_1d_type;
+// extern PyTypeObject integration_rule_1d_type;
+extern PyType_Spec integration_rule_1d_type_spec;
 
 #endif // GAUSSLOBATTO_H

--- a/src/geometry/geoidobject.c
+++ b/src/geometry/geoidobject.c
@@ -6,12 +6,31 @@
 
 static PyObject *geoid_repr(PyObject *self)
 {
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
+    if (!state)
+        return NULL;
+
+    if (!PyObject_TypeCheck(self, state->type_geoid))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_geoid->tp_name, Py_TYPE(self)->tp_name);
+        return NULL;
+    }
+
     const geo_id_object_t *this = (geo_id_object_t *)self;
     return PyUnicode_FromFormat("GeoID(%u, %u)", (unsigned)this->id.index, (unsigned)this->id.reverse);
 }
 
 static PyObject *geoid_str(PyObject *self)
 {
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
+    if (!state)
+        return NULL;
+
+    if (!PyObject_TypeCheck(self, state->type_geoid))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_geoid->tp_name, Py_TYPE(self)->tp_name);
+        return NULL;
+    }
     const geo_id_object_t *this = (geo_id_object_t *)self;
     return PyUnicode_FromFormat("%c%u", (unsigned)this->id.reverse ? '-' : '+', (unsigned)this->id.index);
 }
@@ -53,16 +72,20 @@ static int geoid_set_index(PyObject *self, PyObject *value, void *Py_UNUSED(clos
 }
 
 static PyGetSetDef geoid_getset[] = {
-    {.name = "reversed",
-     .get = geoid_get_orientation,
-     .set = geoid_set_orientation,
-     .doc = "bool : Is the orientation of the object reversed.",
-     .closure = NULL},
-    {.name = "index",
-     .get = geoid_get_index,
-     .set = geoid_set_index,
-     .doc = "int : Index of the object referenced by id.",
-     .closure = NULL},
+    {
+        .name = "reversed",
+        .get = geoid_get_orientation,
+        .set = geoid_set_orientation,
+        .doc = "bool : Is the orientation of the object reversed.",
+        .closure = NULL,
+    },
+    {
+        .name = "index",
+        .get = geoid_get_index,
+        .set = geoid_set_index,
+        .doc = "int : Index of the object referenced by id.",
+        .closure = NULL,
+    },
     {0}, // sentinel
 };
 
@@ -104,13 +127,23 @@ static PyObject *geoid_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 
 static PyObject *geoid_rich_compare(PyObject *self, PyObject *other, const int op)
 {
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
+    if (!state)
+        return NULL;
+
+    if (!PyObject_TypeCheck(self, state->type_geoid))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_geoid->tp_name, Py_TYPE(self)->tp_name);
+        return NULL;
+    }
+
     if (op != Py_EQ && op != Py_NE)
     {
         Py_RETURN_NOTIMPLEMENTED;
     }
     const geo_id_object_t *const this = (geo_id_object_t *)self;
     geo_id_t that;
-    if (geo_id_from_object(Py_TYPE(self), other, &that) < 0)
+    if (geo_id_from_object(state->type_geoid, other, &that) < 0)
     {
         PyErr_Clear();
         Py_RETURN_NOTIMPLEMENTED;
@@ -134,6 +167,15 @@ static int geoid_bool(PyObject *self)
 
 static PyObject *geoid_negative(PyObject *self)
 {
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
+    if (!state)
+        return NULL;
+
+    if (!PyObject_TypeCheck(self, state->type_geoid))
+    {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got %s.", state->type_geoid->tp_name, Py_TYPE(self)->tp_name);
+        return NULL;
+    }
     const geo_id_object_t *const this = (geo_id_object_t *)self;
     return (PyObject *)geo_id_object_from_value(Py_TYPE(self),
                                                 (geo_id_t){.index = this->id.index, .reverse = !this->id.reverse});

--- a/src/geometry/geoidobject.c
+++ b/src/geometry/geoidobject.c
@@ -243,6 +243,7 @@ static PyType_Slot geo_id_type_slots[] = {
     {.slot = Py_tp_richcompare, .pfunc = geoid_rich_compare},
     {.slot = Py_nb_bool, .pfunc = geoid_bool},
     {.slot = Py_nb_negative, .pfunc = geoid_negative},
+    {.slot = Py_tp_traverse, .pfunc = traverse_heap_type},
     {}, // sentinel
 };
 
@@ -250,7 +251,7 @@ PyType_Spec geo_id_type_spec = {
     .name = "mfv2d._mfv2d.GeoID",
     .basicsize = sizeof(geo_id_object_t),
     .itemsize = 0,
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HEAPTYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_HAVE_GC,
     .slots = geo_id_type_slots,
 };
 

--- a/src/geometry/geoidobject.h
+++ b/src/geometry/geoidobject.h
@@ -14,10 +14,11 @@ typedef struct
 } geo_id_object_t;
 
 MFV2D_INTERNAL
-extern PyTypeObject geo_id_type_object;
+// extern PyTypeObject geo_id_type_object;
+extern PyType_Spec geo_id_type_spec;
 
 MFV2D_INTERNAL
-geo_id_object_t *geo_id_object_from_value(geo_id_t id);
+geo_id_object_t *geo_id_object_from_value(PyTypeObject *geo_id_type_object, geo_id_t id);
 
 /**
  * @brief Try to convert PyObject into a geo_id_t value.
@@ -27,12 +28,13 @@ geo_id_object_t *geo_id_object_from_value(geo_id_t id);
  * conversion fails, it will set the Python exception state and function will return -1. If it succeeded instead,
  * 0 is returned.
  *
+ * @param geoid_type Type object for the GeoID type.
  * @param o Object that should be converted.
  * @param p_out Pointer which receives the converted value.
  * @return 0 if successful, -1 if conversion failed.
  */
 MFV2D_INTERNAL
-int geo_id_from_object(PyObject *o, geo_id_t *p_out);
+int geo_id_from_object(PyTypeObject *geoid_type, PyObject *o, geo_id_t *p_out);
 
 static inline int geo_id_compare(const geo_id_t id1, const geo_id_t id2)
 {

--- a/src/geometry/lineobject.c
+++ b/src/geometry/lineobject.c
@@ -113,7 +113,7 @@ PyDoc_STRVAR(line_object_type_docstring, "Line(begin: GeoID | int, end: GeoID | 
 static PyObject *line_object_get_begin(PyObject *self, void *Py_UNUSED(closure))
 {
     const line_object_t *this = (line_object_t *)self;
-    const mfv2d_module_state_t *const state = PyType_GetModuleState(Py_TYPE(self));
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
     if (!state)
         return NULL;
     return (PyObject *)geo_id_object_from_value(state->type_geoid, this->value.begin);
@@ -122,7 +122,7 @@ static PyObject *line_object_get_begin(PyObject *self, void *Py_UNUSED(closure))
 static PyObject *line_object_get_end(PyObject *self, void *Py_UNUSED(closure))
 {
     const line_object_t *this = (line_object_t *)self;
-    const mfv2d_module_state_t *const state = PyType_GetModuleState(Py_TYPE(self));
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
     if (!state)
         return NULL;
     return (PyObject *)geo_id_object_from_value(state->type_geoid, this->value.end);

--- a/src/geometry/lineobject.c
+++ b/src/geometry/lineobject.c
@@ -239,6 +239,7 @@ static PyType_Slot line_type_slots[] = {
     {.slot = Py_tp_richcompare, .pfunc = line_object_rich_compare},
     {.slot = Py_tp_getset, .pfunc = line_object_getset},
     {.slot = Py_tp_methods, .pfunc = line_methods},
+    {.slot = Py_tp_traverse, .pfunc = traverse_heap_type},
     {}, // sentinel
 };
 
@@ -246,6 +247,6 @@ PyType_Spec line_type_spec = {
     .name = "mfv2d._mfv2d.Line",
     .basicsize = sizeof(line_object_t),
     .itemsize = 0,
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HEAPTYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_HAVE_GC,
     .slots = line_type_slots,
 };

--- a/src/geometry/lineobject.h
+++ b/src/geometry/lineobject.h
@@ -14,9 +14,10 @@ typedef struct
 } line_object_t;
 
 MFV2D_INTERNAL
-extern PyTypeObject line_type_object;
+// extern PyTypeObject line_type_object;
+extern PyType_Spec line_type_spec;
 
 MFV2D_INTERNAL
-line_object_t *line_from_indices(geo_id_t begin, geo_id_t end);
+line_object_t *line_from_indices(PyTypeObject *line_type_object, geo_id_t begin, geo_id_t end);
 
 #endif // LINEOBJECT_H

--- a/src/geometry/manifold2d.c
+++ b/src/geometry/manifold2d.c
@@ -93,6 +93,7 @@ PyDoc_STRVAR(manifold2d_type_docstring,
 
 static void manifold2d_dealloc(PyObject *self)
 {
+    PyObject_GC_UnTrack(self);
     manifold2d_object_t *this = (manifold2d_object_t *)self;
 
     PyObject_Free(this->lines);
@@ -933,6 +934,7 @@ static PyType_Slot manifold2d_slots[] = {
     {.slot = Py_tp_methods, .pfunc = manifold2d_object_methods},
     {.slot = Py_tp_getset, .pfunc = manifold2d_getset},
     {.slot = Py_tp_dealloc, .pfunc = manifold2d_dealloc},
+    {.slot = Py_tp_traverse, .pfunc = traverse_heap_type},
     {}, // sentinel
 };
 
@@ -940,6 +942,7 @@ PyType_Spec manifold2d_type_spec = {
     .name = "mfv2d._mfv2d.Manifold2D",
     .basicsize = sizeof(manifold2d_object_t),
     .itemsize = 0,
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE,
+    .flags =
+        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_HAVE_GC,
     .slots = manifold2d_slots,
 };

--- a/src/geometry/manifold2d.c
+++ b/src/geometry/manifold2d.c
@@ -141,7 +141,7 @@ static PyGetSetDef manifold2d_getset[] = {
 
 static PyObject *manifold2d_get_line(PyObject *self, PyObject *arg)
 {
-    const mfv2d_module_state_t *const state = PyType_GetModuleState(Py_TYPE(self));
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
     if (!state)
         return NULL;
 
@@ -178,7 +178,7 @@ static PyObject *manifold2d_get_line(PyObject *self, PyObject *arg)
 
 static PyObject *manifold2d_get_surface(PyObject *self, PyObject *arg)
 {
-    const mfv2d_module_state_t *const state = PyType_GetModuleState(Py_TYPE(self));
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
     if (!state)
         return NULL;
 
@@ -335,7 +335,7 @@ static int mesh_dual_from_primal(const manifold2d_object_t *const primal, manifo
 
 static PyObject *manifold2d_compute_dual(PyObject *self, PyObject *Py_UNUSED(arg))
 {
-    const mfv2d_module_state_t *const state = PyType_GetModuleState(Py_TYPE(self));
+    const mfv2d_module_state_t *const state = mfv2d_state_from_type(Py_TYPE(self));
     if (!state)
         return NULL;
 

--- a/src/geometry/manifold2d.h
+++ b/src/geometry/manifold2d.h
@@ -18,6 +18,7 @@ typedef struct
 } manifold2d_object_t;
 
 MFV2D_INTERNAL
-extern PyTypeObject manifold2d_type_object;
+// extern PyTypeObject manifold2d_type_object;
+extern PyType_Spec manifold2d_type_spec;
 
 #endif // MANIFOLD2D_H

--- a/src/geometry/mesh.c
+++ b/src/geometry/mesh.c
@@ -324,6 +324,7 @@ static PyObject *mesh_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
 static void mesh_dealloc(mesh_t *const this)
 {
+    PyObject_GC_UnTrack(this);
     element_mesh_destroy(&this->element_mesh);
     deallocate(&SYSTEM_ALLOCATOR, this->boundary_indices);
     Py_DECREF(this->primal);
@@ -1583,6 +1584,7 @@ static PyType_Slot mesh_type_slots[] = {
     {.slot = Py_tp_getset, .pfunc = mesh_getset},
     {.slot = Py_tp_methods, .pfunc = mesh_methods},
     {.slot = Py_tp_doc, .pfunc = (void *)mesh_type_docstr},
+    {.slot = Py_tp_traverse, .pfunc = traverse_heap_type},
     {}, // sentinel
 };
 
@@ -1590,6 +1592,7 @@ PyType_Spec mesh_type_spec = {
     .name = "mfv2d._mfv2d.Mesh",
     .basicsize = sizeof(mesh_t),
     .itemsize = 0,
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HEAPTYPE,
+    .flags =
+        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_HAVE_GC,
     .slots = mesh_type_slots,
 };

--- a/src/geometry/mesh.h
+++ b/src/geometry/mesh.h
@@ -72,7 +72,8 @@ typedef struct
 } mesh_t;
 
 MFV2D_INTERNAL
-extern PyTypeObject mesh_type_object;
+// extern PyTypeObject mesh_type_object;
+extern PyType_Spec mesh_type_spec;
 
 typedef enum
 {

--- a/src/geometry/surfaceobject.c
+++ b/src/geometry/surfaceobject.c
@@ -339,6 +339,7 @@ static PyType_Slot surface_slots[] = {
     {.slot = Py_tp_methods, .pfunc = surface_methods},
     {.slot = Py_sq_length, .pfunc = surface_sequence_length},
     {.slot = Py_sq_item, .pfunc = surface_sequence_item},
+    {.slot = Py_tp_traverse, .pfunc = traverse_heap_type},
     {} // sentinel
 };
 
@@ -346,6 +347,6 @@ PyType_Spec surface_type_spec = {
     .name = "mfv2d._mfv2d.Surface",
     .basicsize = sizeof(surface_object_t),
     .itemsize = sizeof(geo_id_t),
-    .flags = Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_HEAPTYPE | Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_HAVE_GC,
     .slots = surface_slots,
 };

--- a/src/geometry/surfaceobject.c
+++ b/src/geometry/surfaceobject.c
@@ -266,7 +266,7 @@ static Py_ssize_t surface_sequence_length(PyObject *self)
 static PyObject *surface_sequence_item(PyObject *self, Py_ssize_t idx)
 {
     const surface_object_t *this = (surface_object_t *)self;
-    const mfv2d_module_state_t *state = PyType_GetModuleState(Py_TYPE(self));
+    const mfv2d_module_state_t *state = mfv2d_state_from_type(Py_TYPE(self));
     if (!state)
         return NULL;
 

--- a/src/geometry/surfaceobject.h
+++ b/src/geometry/surfaceobject.h
@@ -15,12 +15,11 @@ typedef struct
 } surface_object_t;
 
 MFV2D_INTERNAL
-extern PyTypeObject surface_type_object;
+// extern PyTypeObject surface_type_object;
+extern PyType_Spec surface_type_spec;
 
 MFV2D_INTERNAL
-surface_object_t *surface_object_empty(size_t count);
-
-MFV2D_INTERNAL
-surface_object_t *surface_object_from_value(size_t count, geo_id_t ids[static count]);
+surface_object_t *surface_object_from_value(PyTypeObject *surface_type_object, size_t count,
+                                            geo_id_t ids[static count]);
 
 #endif // SURFACEOBJECT_H

--- a/src/module.c
+++ b/src/module.c
@@ -188,8 +188,10 @@ PyMODINIT_FUNC PyInit__mfv2d(void)
         (state->type_surface = add_type_to_the_module(mod, &surface_type_spec, NULL)) == NULL ||
         (state->type_man2d = add_type_to_the_module(mod, &manifold2d_type_spec, NULL)) == NULL ||
         (state->type_mesh = add_type_to_the_module(mod, &mesh_type_spec, NULL)) == NULL ||
-        PyModule_AddType(mod, &integration_rule_1d_type) < 0 || PyModule_AddType(mod, &basis_1d_type) < 0 ||
-        PyModule_AddType(mod, &basis_2d_type) < 0 || PyModule_AddType(mod, &element_fem_space_2d_type) < 0 ||
+        (state->type_int_rule = add_type_to_the_module(mod, &integration_rule_1d_type_spec, NULL)) == NULL ||
+        (state->type_basis1d = add_type_to_the_module(mod, &basis_1d_type_spec, NULL)) == NULL ||
+        (state->type_basis2d = add_type_to_the_module(mod, &basis_2d_type_spec, NULL)) == NULL ||
+        (state->type_fem_space = add_type_to_the_module(mod, &element_fem_space_2d_type_spec, NULL)) == NULL ||
         PyModule_AddType(mod, &element_form_spec_type) < 0 || PyModule_AddType(mod, &element_form_spec_iter_type) < 0 ||
         PyModule_AddType(mod, &svec_type_object) < 0 || PyModule_AddType(mod, &crs_matrix_type_object) < 0 ||
         PyModule_AddType(mod, &system_object_type) < 0 || PyModule_AddType(mod, &trace_vector_object_type) < 0 ||

--- a/src/module.c
+++ b/src/module.c
@@ -192,7 +192,8 @@ PyMODINIT_FUNC PyInit__mfv2d(void)
         (state->type_basis1d = add_type_to_the_module(mod, &basis_1d_type_spec, NULL)) == NULL ||
         (state->type_basis2d = add_type_to_the_module(mod, &basis_2d_type_spec, NULL)) == NULL ||
         (state->type_fem_space = add_type_to_the_module(mod, &element_fem_space_2d_type_spec, NULL)) == NULL ||
-        PyModule_AddType(mod, &element_form_spec_type) < 0 || PyModule_AddType(mod, &element_form_spec_iter_type) < 0 ||
+        (state->type_form_spec = add_type_to_the_module(mod, &element_form_spec_type_spec, NULL)) == NULL ||
+        (state->type_form_spec_iter = add_type_to_the_module(mod, &element_form_spec_iter_type_spec, NULL)) == NULL ||
         PyModule_AddType(mod, &svec_type_object) < 0 || PyModule_AddType(mod, &crs_matrix_type_object) < 0 ||
         PyModule_AddType(mod, &system_object_type) < 0 || PyModule_AddType(mod, &trace_vector_object_type) < 0 ||
         PyModule_AddType(mod, &dense_vector_object_type) < 0 || PyModule_AddIntMacro(mod, ELEMENT_SIDE_BOTTOM) < 0 ||

--- a/src/module.h
+++ b/src/module.h
@@ -1,5 +1,5 @@
-#ifndef MIMETIC_MODULE_H
-#define MIMETIC_MODULE_H
+#ifndef MFV2D_MODULE_H
+#define MFV2D_MODULE_H
 
 typedef unsigned index_t;
 _Static_assert(sizeof(index_t) == 4, "This must be for the geo_id_t to make sense");
@@ -29,4 +29,4 @@ typedef struct
     geo_id_t *values;
 } surface_t;
 
-#endif // MIMETIC_MODULE_H
+#endif // MFV2D_MODULE_H

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,0 +1,49 @@
+"""Check extension works as intended."""
+
+import sys
+
+
+def compute_l2_of_laplace_equation(mfv2d, nh: int, nv: int, order: int) -> float:
+    """Solve test Laplace equation and compute the L2 norm of the solution."""
+    mesh = mfv2d.examples.unit_square_mesh(nh, nv, order)
+
+    def u_exact(x, y):
+        return (x * y) ** 2
+
+    u = mfv2d.KFormUnknown("u", mfv2d.UnknownFormOrder.FORM_ORDER_2)
+    q = mfv2d.KFormUnknown("q", mfv2d.UnknownFormOrder.FORM_ORDER_1)
+    v = u.weight
+    p = q.weight
+
+    system = mfv2d.KFormSystem(
+        p @ q + p.derivative @ u == p ^ u_exact,
+        v @ q.derivative == 0,
+    )
+
+    sol, _, _ = mfv2d.solve_system_2d(mesh, mfv2d.SystemSettings(system))
+
+    return float(sol[-1].integrate_data().point_data[u.label][0])
+
+
+def test_subinterpreters():
+    """Check that the module isolation works."""
+    NH = 3
+    NV = 4
+    P = 3
+
+    import mfv2d
+
+    mod1 = mfv2d
+    del sys.modules["mfv2d"]
+    del mfv2d
+
+    import mfv2d
+
+    mod2 = mfv2d
+    del sys.modules["mfv2d"]
+    del mfv2d
+
+    assert mod1 != mod2
+    assert compute_l2_of_laplace_equation(
+        mod1, NH, NV, P
+    ) == compute_l2_of_laplace_equation(mod2, NH, NV, P)


### PR DESCRIPTION
## Summary

The extension has now been converted to use modern Python heap types. This allows for multiple distinct module instances, which in theory supports sub-interpreters.